### PR TITLE
Add support for Debian changelog files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ categories = ["development-tools", "text-editors"]
 
 [dependencies]
 # debian-analyzer = "0.159.0"
+debian-changelog = "0.2"
 debian-control = "0.2"
 debian-copyright = { version = "0.1.41", features = ["lossless"] }
 debian-watch = { version = "0.4.1", features = ["linebased", "deb822"] }
+distro-info = "0.4"
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/changelog/completion.rs
+++ b/src/changelog/completion.rs
@@ -1,0 +1,132 @@
+use tower_lsp_server::ls_types::{
+    CompletionItem, CompletionItemKind, Documentation, Position, Uri,
+};
+
+use super::detection::is_changelog_file;
+use super::fields::{get_debian_distributions, URGENCY_LEVELS};
+
+/// Get completion items for a given position in a changelog file
+pub fn get_completions(uri: &Uri, _position: Position) -> Vec<CompletionItem> {
+    if !is_changelog_file(uri) {
+        return Vec::new();
+    }
+
+    let mut completions = Vec::new();
+    completions.extend(get_distribution_completions());
+    completions.extend(get_urgency_completions());
+    completions
+}
+
+/// Get completion items for Debian distributions
+pub fn get_distribution_completions() -> Vec<CompletionItem> {
+    get_debian_distributions()
+        .iter()
+        .map(|dist| CompletionItem {
+            label: dist.clone(),
+            kind: Some(CompletionItemKind::VALUE),
+            detail: Some("Debian distribution".to_string()),
+            documentation: Some(Documentation::String(format!(
+                "Target distribution: {}",
+                dist
+            ))),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Get completion items for urgency levels
+pub fn get_urgency_completions() -> Vec<CompletionItem> {
+    URGENCY_LEVELS
+        .iter()
+        .map(|level| CompletionItem {
+            label: level.name.to_string(),
+            kind: Some(CompletionItemKind::VALUE),
+            detail: Some("Urgency level".to_string()),
+            documentation: Some(Documentation::String(level.description.to_string())),
+            insert_text: Some(format!("urgency={}", level.name)),
+            ..Default::default()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_completions_for_changelog_file() {
+        let uri = str::parse("file:///path/to/debian/changelog").unwrap();
+        let position = Position::new(0, 0);
+
+        let completions = get_completions(&uri, position);
+        assert!(!completions.is_empty());
+
+        // Should have both distribution and urgency completions
+        let value_count = completions
+            .iter()
+            .filter(|c| c.kind == Some(CompletionItemKind::VALUE))
+            .count();
+
+        assert!(value_count > 0);
+    }
+
+    #[test]
+    fn test_get_completions_for_non_changelog_file() {
+        let uri = str::parse("file:///path/to/other.txt").unwrap();
+        let position = Position::new(0, 0);
+
+        let completions = get_completions(&uri, position);
+        assert!(completions.is_empty());
+    }
+
+    #[test]
+    fn test_distribution_completions() {
+        let completions = get_distribution_completions();
+
+        assert!(!completions.is_empty());
+
+        // Check that all completions have required properties
+        for completion in &completions {
+            assert!(!completion.label.is_empty());
+            assert_eq!(completion.kind, Some(CompletionItemKind::VALUE));
+            assert!(completion.detail.is_some());
+            assert!(completion.documentation.is_some());
+        }
+
+        // Check for specific distributions
+        let labels: Vec<_> = completions.iter().map(|c| &c.label).collect();
+        assert!(labels.iter().any(|l| *l == "unstable"));
+        assert!(labels.iter().any(|l| *l == "stable"));
+        assert!(labels.iter().any(|l| *l == "UNRELEASED"));
+    }
+
+    #[test]
+    fn test_urgency_completions() {
+        let completions = get_urgency_completions();
+
+        assert!(!completions.is_empty());
+        assert_eq!(completions.len(), 5);
+
+        // Check that all completions have required properties
+        for completion in &completions {
+            assert!(!completion.label.is_empty());
+            assert_eq!(completion.kind, Some(CompletionItemKind::VALUE));
+            assert!(completion.detail.is_some());
+            assert!(completion.documentation.is_some());
+            assert!(completion.insert_text.is_some());
+            assert!(completion
+                .insert_text
+                .as_ref()
+                .unwrap()
+                .starts_with("urgency="));
+        }
+
+        // Check for specific urgency levels
+        let labels: Vec<_> = completions.iter().map(|c| &c.label).collect();
+        assert!(labels.iter().any(|l| *l == "low"));
+        assert!(labels.iter().any(|l| *l == "medium"));
+        assert!(labels.iter().any(|l| *l == "high"));
+        assert!(labels.iter().any(|l| *l == "critical"));
+        assert!(labels.iter().any(|l| *l == "emergency"));
+    }
+}

--- a/src/changelog/detection.rs
+++ b/src/changelog/detection.rs
@@ -1,0 +1,47 @@
+use tower_lsp_server::ls_types::Uri;
+
+/// Check if a given URL represents a Debian changelog file
+pub fn is_changelog_file(uri: &Uri) -> bool {
+    let path = uri.as_str();
+    path.ends_with("/changelog") || path.ends_with("/debian/changelog")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_changelog_file() {
+        let changelog_paths = vec![
+            "file:///path/to/debian/changelog",
+            "file:///project/debian/changelog",
+            "file:///changelog",
+            "file:///some/path/changelog",
+        ];
+
+        let non_changelog_paths = vec![
+            "file:///path/to/other.txt",
+            "file:///path/to/changelog.txt",
+            "file:///path/to/mychangelog",
+            "file:///path/to/debian/changelog.backup",
+        ];
+
+        for path in changelog_paths {
+            let uri = path.parse::<Uri>().unwrap();
+            assert!(
+                is_changelog_file(&uri),
+                "Should detect changelog file: {}",
+                path
+            );
+        }
+
+        for path in non_changelog_paths {
+            let uri = path.parse::<Uri>().unwrap();
+            assert!(
+                !is_changelog_file(&uri),
+                "Should not detect as changelog file: {}",
+                path
+            );
+        }
+    }
+}

--- a/src/changelog/fields.rs
+++ b/src/changelog/fields.rs
@@ -1,0 +1,126 @@
+/// Debian changelog field definitions and common values
+use distro_info::{DebianDistroInfo, DistroInfo};
+
+/// Debian urgency levels for changelog entries
+pub struct UrgencyLevel {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+impl UrgencyLevel {
+    pub const fn new(name: &'static str, description: &'static str) -> Self {
+        Self { name, description }
+    }
+}
+
+/// All available urgency levels
+pub const URGENCY_LEVELS: &[UrgencyLevel] = &[
+    UrgencyLevel::new("low", "Low urgency update"),
+    UrgencyLevel::new("medium", "Medium urgency update"),
+    UrgencyLevel::new("high", "High urgency update"),
+    UrgencyLevel::new("critical", "Critical urgency update"),
+    UrgencyLevel::new("emergency", "Emergency urgency update"),
+];
+
+/// Common changelog entry prefixes
+pub const CHANGELOG_PREFIXES: &[&str] = &["* ", "  + ", "  - ", "    - "];
+
+/// Get the standard casing for an urgency level
+pub fn get_standard_urgency_name(urgency: &str) -> Option<&'static str> {
+    let lowercase = urgency.to_lowercase();
+    for level in URGENCY_LEVELS {
+        if level.name.to_lowercase() == lowercase {
+            return Some(level.name);
+        }
+    }
+    None
+}
+
+/// Get Debian distribution names from distro-info-data
+/// Returns a vector of distribution names (codenames and aliases)
+pub fn get_debian_distributions() -> Vec<String> {
+    // Add common aliases first
+    let mut distributions = vec![
+        "unstable".to_string(),
+        "stable".to_string(),
+        "testing".to_string(),
+        "oldstable".to_string(),
+        "experimental".to_string(),
+        "sid".to_string(),
+        "UNRELEASED".to_string(),
+    ];
+
+    // Try to get distribution data from distro-info
+    if let Ok(debian_info) = DebianDistroInfo::new() {
+        // Add all release codenames
+        for release in debian_info.iter() {
+            let series = release.series();
+            if !distributions.contains(&series.to_string()) {
+                distributions.push(series.to_string());
+            }
+        }
+    }
+
+    distributions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_urgency_levels() {
+        assert!(!URGENCY_LEVELS.is_empty());
+        assert_eq!(URGENCY_LEVELS.len(), 5);
+
+        let urgency_names: Vec<_> = URGENCY_LEVELS.iter().map(|u| u.name).collect();
+        assert!(urgency_names.contains(&"low"));
+        assert!(urgency_names.contains(&"medium"));
+        assert!(urgency_names.contains(&"high"));
+        assert!(urgency_names.contains(&"critical"));
+        assert!(urgency_names.contains(&"emergency"));
+    }
+
+    #[test]
+    fn test_urgency_level_validity() {
+        for level in URGENCY_LEVELS {
+            assert!(!level.name.is_empty());
+            assert!(!level.description.is_empty());
+            assert!(
+                level.name.chars().all(|c| c.is_ascii_lowercase()),
+                "Urgency level {} should be lowercase",
+                level.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_standard_urgency_name() {
+        assert_eq!(get_standard_urgency_name("low"), Some("low"));
+        assert_eq!(get_standard_urgency_name("LOW"), Some("low"));
+        assert_eq!(get_standard_urgency_name("Low"), Some("low"));
+        assert_eq!(get_standard_urgency_name("medium"), Some("medium"));
+        assert_eq!(get_standard_urgency_name("MEDIUM"), Some("medium"));
+        assert_eq!(get_standard_urgency_name("invalid"), None);
+    }
+
+    #[test]
+    fn test_changelog_prefixes() {
+        assert!(!CHANGELOG_PREFIXES.is_empty());
+        assert!(CHANGELOG_PREFIXES.contains(&"* "));
+        assert!(CHANGELOG_PREFIXES.contains(&"  + "));
+    }
+
+    #[test]
+    fn test_get_debian_distributions() {
+        let distributions = get_debian_distributions();
+        assert!(!distributions.is_empty());
+
+        // Check that common aliases are present
+        assert!(distributions.contains(&"unstable".to_string()));
+        assert!(distributions.contains(&"stable".to_string()));
+        assert!(distributions.contains(&"testing".to_string()));
+        assert!(distributions.contains(&"UNRELEASED".to_string()));
+        assert!(distributions.contains(&"sid".to_string()));
+    }
+}

--- a/src/changelog/mod.rs
+++ b/src/changelog/mod.rs
@@ -1,0 +1,6 @@
+pub mod completion;
+pub mod detection;
+pub mod fields;
+
+pub use completion::*;
+pub use detection::is_changelog_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use tower_lsp_server::ls_types::NumberOrString;
 use tower_lsp_server::ls_types::*;
 use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 
+mod changelog;
 mod control;
 mod copyright;
 mod position;
@@ -113,6 +114,16 @@ impl LanguageServer for Backend {
             files.insert(params.text_document.uri.clone(), file);
 
             // No diagnostics for watch files yet
+        } else if changelog::is_changelog_file(&params.text_document.uri) {
+            let mut workspace = self.workspace.lock().await;
+            let file = workspace.update_file(
+                params.text_document.uri.clone(),
+                params.text_document.text.clone(),
+            );
+            let mut files = self.files.lock().await;
+            files.insert(params.text_document.uri.clone(), file);
+
+            // No diagnostics for changelog files yet
         }
     }
 
@@ -171,6 +182,19 @@ impl LanguageServer for Backend {
 
                 // No diagnostics for watch files yet
             }
+        } else if changelog::is_changelog_file(&params.text_document.uri) {
+            let mut workspace = self.workspace.lock().await;
+            let mut files = self.files.lock().await;
+
+            // Apply the content changes
+            if let Some(changes) = params.content_changes.first() {
+                // Update or create the file
+                let file =
+                    workspace.update_file(params.text_document.uri.clone(), changes.text.clone());
+                files.insert(params.text_document.uri.clone(), file);
+
+                // No diagnostics for changelog files yet
+            }
         }
     }
 
@@ -188,6 +212,11 @@ impl LanguageServer for Backend {
         // If no copyright completions, try watch completions
         if completions.is_empty() {
             completions = watch::get_completions(&uri, position);
+        }
+
+        // If no watch completions, try changelog completions
+        if completions.is_empty() {
+            completions = changelog::get_completions(&uri, position);
         }
 
         if completions.is_empty() {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -52,6 +52,15 @@ pub fn parse_watch(db: &dyn salsa::Database, file: SourceFile) -> debian_watch::
     debian_watch::parse::Parse::parse(&text)
 }
 
+#[salsa::tracked]
+pub fn parse_changelog(
+    db: &dyn salsa::Database,
+    file: SourceFile,
+) -> debian_changelog::Parse<debian_changelog::ChangeLog> {
+    let text = file.text(db);
+    debian_changelog::ChangeLog::parse(&text)
+}
+
 // The actual database implementation
 #[salsa::db]
 #[derive(Clone, Default)]
@@ -351,6 +360,13 @@ impl Workspace {
     pub fn get_parsed_watch(&self, file: SourceFile) -> debian_watch::parse::Parse {
         parse_watch(self, file)
     }
+
+    pub fn get_parsed_changelog(
+        &self,
+        file: SourceFile,
+    ) -> debian_changelog::Parse<debian_changelog::ChangeLog> {
+        parse_changelog(self, file)
+    }
 }
 
 #[cfg(test)]
@@ -568,5 +584,46 @@ Matching-Pattern: .*/v?(\d[\d.]*)\.tar\.gz
 
         // Should default to version 1
         assert_eq!(parsed.version(), 1);
+    }
+
+    #[test]
+    fn test_parse_changelog_basic() {
+        let mut workspace = Workspace::new();
+        let url = str::parse("file:///debian/changelog").unwrap();
+        let content = r#"rust-foo (0.1.0-1) unstable; urgency=medium
+
+  * Initial release.
+
+ -- John Doe <john@example.com>  Mon, 01 Jan 2024 12:00:00 +0000
+"#;
+
+        let file = workspace.update_file(url, content.to_string());
+        let parsed = workspace.get_parsed_changelog(file);
+
+        assert!(parsed.errors().is_empty());
+    }
+
+    #[test]
+    fn test_parse_changelog_multiple_entries() {
+        let mut workspace = Workspace::new();
+        let url = str::parse("file:///debian/changelog").unwrap();
+        let content = r#"rust-foo (0.2.0-1) unstable; urgency=high
+
+  * New upstream release.
+  * Fix security vulnerability.
+
+ -- John Doe <john@example.com>  Tue, 02 Jan 2024 12:00:00 +0000
+
+rust-foo (0.1.0-1) unstable; urgency=medium
+
+  * Initial release.
+
+ -- John Doe <john@example.com>  Mon, 01 Jan 2024 12:00:00 +0000
+"#;
+
+        let file = workspace.update_file(url, content.to_string());
+        let parsed = workspace.get_parsed_changelog(file);
+
+        assert!(parsed.errors().is_empty());
     }
 }


### PR DESCRIPTION
Implements LSP support for debian/changelog files with completions for distribution names (using distro-info crate) and urgency levels. Follows the same module pattern as control, copyright, and watch files.