### PR TITLE
docs: fix Generic LSP Client setup instructions for VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,24 +56,6 @@ The binary will be available at `target/release/debian-lsp`.
 
 A dedicated VS Code extension is available in the `vscode-debian` directory. See [vscode-debian/README.md](vscode-debian/README.md) for installation and configuration instructions.
 
-Alternatively, you can use the generic LSP client extension:
-
-1. Install the "[Generic LSP Client](https://marketplace.visualstudio.com/items?itemName=llllvvuu.llllvvuu-glspc)" extension
-2. Add to your `settings.json`:
-
-```json
-{
-  "glspc.languageId": "plaintext",
-  "glspc.serverCommand": "/path/to/debian-lsp/target/release/debian-lsp",
-  "files.associations": {
-      "**/debian/control": "plaintext",
-      "**/debian/copyright": "plaintext",
-      "**/debian/watch": "plaintext",
-      "**/debian/tests/control": "plaintext",
-  }
-}
-```
-
 ### Using with Vim/Neovim
 
 #### coc.nvim


### PR DESCRIPTION
The current documentation describes two ways of using the LSP server in VSCode on the client side:

1. Using a custom-built extension  
2. Using a generic LSP client

However, the instructions for the second option are not fully correct:

- The `"genericLanguageServer.configurations"` option does not exist in the **Generic LSP Client** extension referenced in the documentation.
- The `"debcontrol"` `languageId` does not exist.

There are two ways to resolve the `languageId` issue:

1. **Install a [Debian-related extension](https://marketplace.visualstudio.com/items?itemName=dawidd6.debian-vscode)** that detects Debian control files.  
   In that case the correct `languageId` is `"debian-control"`.

2. **Use `"plaintext"` as the `languageId`**, and associate Debian files with the `plaintext` language in VSCode.

With the second approach, the configuration is shown in the updated README included in this PR.