### PR TITLE
debian-lsp: add value completions for control fields

### DIFF
--- a/src/control/completion.rs
+++ b/src/control/completion.rs
@@ -1,8 +1,9 @@
 use tower_lsp_server::ls_types::{CompletionItem, CompletionItemKind};
 
 use super::fields::{
-    COMMON_PACKAGES, CONTROL_FIELDS, CONTROL_PRIORITY_VALUES, CONTROL_SECTION_AREAS,
-    CONTROL_SECTION_VALUES, CONTROL_SPECIAL_SECTION_VALUES,
+    ARCHITECTURE_VALUES, COMMON_PACKAGES, CONTROL_FIELDS, CONTROL_PRIORITY_VALUES,
+    CONTROL_SECTION_AREAS, CONTROL_SECTION_VALUES, CONTROL_SPECIAL_SECTION_VALUES,
+    DEBIAN_BOOLEAN_VALUES, MULTI_ARCH_VALUES,
 };
 
 /// Get completions for a control file at the given cursor position.
@@ -39,6 +40,16 @@ pub fn get_field_value_completions(field_name: &str, prefix: &str) -> Vec<Comple
         get_section_value_completions(prefix)
     } else if field_name.eq_ignore_ascii_case("Priority") {
         get_priority_value_completions(prefix)
+    } else if field_name.eq_ignore_ascii_case("Protected") {
+        get_boolean_value_completions()
+    } else if field_name.eq_ignore_ascii_case("Essential") {
+        get_boolean_value_completions()
+    } else if field_name.eq_ignore_ascii_case("Build-Essential") {
+        get_boolean_value_completions()
+    } else if field_name.eq_ignore_ascii_case("Architecture") {
+        get_architecture_value_completions()
+    } else if field_name.eq_ignore_ascii_case("Multi-Arch") {
+        get_multiarch_value_completions()
     } else {
         vec![]
     }
@@ -69,6 +80,45 @@ pub fn get_priority_value_completions(prefix: &str) -> Vec<CompletionItem> {
             kind: Some(CompletionItemKind::VALUE),
             detail: Some(description.to_string()),
             insert_text: Some(value.to_string()),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Get completion items for Debian priority values.
+pub fn get_boolean_value_completions() -> Vec<CompletionItem> {
+    DEBIAN_BOOLEAN_VALUES
+        .iter()
+        .map(|&val| CompletionItem {
+            label: val.to_string(),
+            kind: Some(CompletionItemKind::VALUE),
+            detail: Some("Section value".to_string()),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Get completion items for Debian architecture values.
+pub fn get_architecture_value_completions() -> Vec<CompletionItem> {
+    ARCHITECTURE_VALUES
+        .iter()
+        .map(|&val| CompletionItem {
+            label: val.to_string(),
+            kind: Some(CompletionItemKind::VALUE),
+            detail: Some("Section value".to_string()),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Get completion items for Debian multi architecture values.
+pub fn get_multiarch_value_completions() -> Vec<CompletionItem> {
+    MULTI_ARCH_VALUES
+        .iter()
+        .map(|&val| CompletionItem {
+            label: val.to_string(),
+            kind: Some(CompletionItemKind::VALUE),
+            detail: Some("Section value".to_string()),
             ..Default::default()
         })
         .collect()

--- a/src/control/fields.rs
+++ b/src/control/fields.rs
@@ -144,6 +144,18 @@ pub const CONTROL_SECTION_AREAS: &[&str] = &["contrib", "non-free", "non-free-fi
 pub const CONTROL_SPECIAL_SECTION_VALUES: &[(&str, &str)] =
     &[("debian-installer", "Debian installer components")];
 
+/// Debian boolean values.
+pub const DEBIAN_BOOLEAN_VALUES: &[&str] = &["yes", "no"];
+
+/// Debian architecture values.
+pub const ARCHITECTURE_VALUES: &[&str] = &[
+    "all", "amd64", "arm64", "armel", "armhf", "i386", "mips", "mips64el", "mipsel", "ppc64el",
+    "s390x",
+];
+
+/// Debian multi-architecture values.
+pub const MULTI_ARCH_VALUES: &[&str] = &["allowed", "foreign", "no", "same"];
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Add value completions for multiarch, architecture, build, build-essentials, essential fields