### PR TITLE
coc-debian: Add semantic token highlight support

### DIFF
--- a/coc-debian/package.json
+++ b/coc-debian/package.json
@@ -44,7 +44,64 @@
           "description": "Path to debian-lsp executable"
         }
       }
-    }
+    },
+    "semanticTokenTypes": [
+      {
+        "id": "debianField",
+        "superType": "property",
+        "description": "Known Debian control field"
+      },
+      {
+        "id": "debianUnknownField",
+        "superType": "variable",
+        "description": "Unknown or custom Debian control field"
+      },
+      {
+        "id": "debianValue",
+        "superType": "string",
+        "description": "Field value"
+      },
+      {
+        "id": "debianComment",
+        "superType": "comment",
+        "description": "Comment line"
+      },
+      {
+        "id": "changelogPackage",
+        "superType": "namespace",
+        "description": "Package name in changelog entry header"
+      },
+      {
+        "id": "changelogVersion",
+        "superType": "number",
+        "description": "Version string in changelog entry header"
+      },
+      {
+        "id": "changelogDistribution",
+        "superType": "enumMember",
+        "description": "Distribution name (e.g. unstable, UNRELEASED)"
+      },
+      {
+        "id": "changelogUrgency",
+        "superType": "keyword",
+        "description": "Urgency key in changelog metadata"
+      },
+      {
+        "id": "changelogMaintainer",
+        "superType": "variable",
+        "description": "Maintainer name and email in changelog trailer"
+      },
+      {
+        "id": "changelogTimestamp",
+        "superType": "string",
+        "description": "Timestamp in changelog trailer"
+      },
+      {
+        "id": "changelogMetadataValue",
+        "superType": "string",
+        "description": "Metadata value in changelog header (e.g. urgency level)"
+      }
+    ]
   },
   "scripts": {
     "build": "tsc -p .",

--- a/coc-debian/src/index.ts
+++ b/coc-debian/src/index.ts
@@ -7,16 +7,50 @@ import {
   workspace
 } from 'coc.nvim';
 
+/**
+ * Set up highlight links for semantic token types.
+ *
+ * coc.nvim creates highlight groups named CocSemType<tokenType> for each
+ * semantic token type reported by the server. By default only standard LSP
+ * types get linked, so we link the custom debian-lsp types to Vim groups.
+ */
+function setupSemanticHighlights(): void {
+  const { nvim } = workspace;
+
+  const links: Record<string, string> = {
+    // deb822 field types
+    CocSemTypedebianField: 'Identifier',
+    CocSemTypedebianUnknownField: 'PreProc',
+    CocSemTypedebianValue: 'String',
+    CocSemTypedebianComment: 'Comment',
+
+    // Changelog-specific types
+    CocSemTypechangelogPackage: 'Title',
+    CocSemTypechangelogVersion: 'Number',
+    CocSemTypechangelogDistribution: 'Constant',
+    CocSemTypechangelogUrgency: 'Keyword',
+    CocSemTypechangelogMaintainer: 'Special',
+    CocSemTypechangelogTimestamp: 'String',
+    CocSemTypechangelogMetadataValue: 'String',
+  };
+
+  for (const [group, target] of Object.entries(links)) {
+    nvim.command(`hi default link ${group} ${target}`, true);
+  }
+}
+
 export async function activate(context: ExtensionContext): Promise<void> {
   const config = workspace.getConfiguration('debian');
   const isEnable = config.get<boolean>('enable', true);
-  
+
   if (!isEnable) {
     return;
   }
 
+  setupSemanticHighlights();
+
   const serverPath = config.get<string>('serverPath', 'debian-lsp');
-  
+
   const serverOptions: ServerOptions = {
     command: serverPath,
     args: []


### PR DESCRIPTION
Register custom semantic token types in package.json and link them to standard Vim highlight groups (CocSemType<type>) so that coc.nvim applies proper syntax highlighting when semanticTokens.enable is set.