### PR TITLE
Disable color decorators for Debian file types

### DIFF
--- a/vscode-debian/package.json
+++ b/vscode-debian/package.json
@@ -118,6 +118,29 @@
         "configuration": "./language-configuration.json"
       }
     ],
+    "configurationDefaults": {
+      "[debchangelog]": {
+        "editor.colorDecorators": false
+      },
+      "[debcontrol]": {
+        "editor.colorDecorators": false
+      },
+      "[debcopyright]": {
+        "editor.colorDecorators": false
+      },
+      "[debwatch]": {
+        "editor.colorDecorators": false
+      },
+      "[debtestscontrol]": {
+        "editor.colorDecorators": false
+      },
+      "[debsourceformat]": {
+        "editor.colorDecorators": false
+      },
+      "[debupstreammetadata]": {
+        "editor.colorDecorators": false
+      }
+    },
     "configuration": {
       "type": "object",
       "title": "Debian Language Server",


### PR DESCRIPTION
Bug IDs like #123456 were being rendered as color swatches by VS Code's color decorator feature since they match the hex color pattern.