### PR TITLE
Avoid redundant re-parsing and use incremental text sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "debian-watch"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c65dcd9d3e23f941e8e4eb80bbcf9c6643cf3064f4b5a19a14bc43b176440a"
+checksum = "2caf4ad059a6070b2baf8563486434236985ff41628c0a3a62e7a7faaa2f0a28"
 dependencies = [
  "clap",
  "deb822-lossless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4"
 debian-changelog = "0.2.15"
 debian-control = { version = "0.3.3" }
 debian-copyright = { version = "0.1.43", features = ["lossless"] }
-debian-watch = { version = "0.4.5", features = ["linebased", "deb822"] }
+debian-watch = { version = "0.4.6", features = ["linebased", "deb822"] }
 distro-info = "0.4"
 rowan = "0.16.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ impl LanguageServer for Backend {
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::FULL,
+                    TextDocumentSyncKind::INCREMENTAL,
                 )),
                 completion_provider: Some(CompletionOptions {
                     resolve_provider: None,
@@ -245,8 +245,8 @@ impl LanguageServer for Backend {
 
         // Get or detect the file type
         let mut files = self.files.lock().await;
-        let file_type = files
-            .get(&params.text_document.uri)
+        let file_info = files.get(&params.text_document.uri).copied();
+        let file_type = file_info
             .map(|info| info.file_type)
             .or_else(|| FileType::detect(&params.text_document.uri));
 
@@ -254,14 +254,31 @@ impl LanguageServer for Backend {
             return;
         };
 
-        // Apply the content changes
-        let Some(changes) = params.content_changes.first() else {
+        if params.content_changes.is_empty() {
             return;
-        };
+        }
 
+        // Apply incremental content changes to the current text
         let mut workspace = self.workspace.lock().await;
-        let source_file =
-            workspace.update_file(params.text_document.uri.clone(), changes.text.clone());
+        let mut text = file_info
+            .map(|info| workspace.source_text(info.source_file))
+            .unwrap_or_default();
+
+        for change in &params.content_changes {
+            if let Some(range) = &change.range {
+                // Incremental change: splice the range
+                if let Some(text_range) = position::try_lsp_range_to_text_range(&text, range) {
+                    let start: usize = text_range.start().into();
+                    let end: usize = text_range.end().into();
+                    text.replace_range(start..end, &change.text);
+                }
+            } else {
+                // Full replacement
+                text = change.text.clone();
+            }
+        }
+
+        let source_file = workspace.update_file(params.text_document.uri.clone(), text);
         files.insert(
             params.text_document.uri.clone(),
             FileInfo {
@@ -300,13 +317,13 @@ impl LanguageServer for Backend {
                     &source_text,
                     position,
                 );
-                drop(workspace);
                 if let Some(deb822::completion::CursorContext::FieldValue {
                     field_name,
                     value_prefix,
                 }) = &cursor_context
                 {
-                    // Try async completions (relationship fields via package cache)
+                    drop(workspace); // Release lock before async operations
+                                     // Try async completions (relationship fields via package cache)
                     if let Some(async_completions) = control::get_async_field_value_completions(
                         field_name,
                         value_prefix,
@@ -323,9 +340,7 @@ impl LanguageServer for Backend {
                     }
                 } else {
                     // Not on a field value — get field name completions
-                    let workspace = self.workspace.lock().await;
-                    let source_text = workspace.source_text(source_file);
-                    let parsed = workspace.get_parsed_control(source_file);
+                    // (workspace lock and parsed result already held)
                     control::get_completions(parsed.tree().as_deb822(), &source_text, position)
                 }
             }
@@ -345,11 +360,8 @@ impl LanguageServer for Backend {
                     debian_watch::parse::ParsedWatchFile::LineBased(wf) => {
                         watch::get_linebased_completions(&uri, wf, &source_text, position)
                     }
-                    debian_watch::parse::ParsedWatchFile::Deb822(_) => {
-                        deb822_lossless::Deb822::parse(&source_text)
-                            .to_result()
-                            .map(|d| watch::get_completions_deb822(&d, &source_text, position))
-                            .unwrap_or_default()
+                    debian_watch::parse::ParsedWatchFile::Deb822(wf) => {
+                        watch::get_completions_deb822(wf.as_deb822(), &source_text, position)
                     }
                 }
             }
@@ -582,7 +594,10 @@ impl LanguageServer for Backend {
                 let parsed = workspace.get_parsed_watch(file.source_file);
                 watch::generate_semantic_tokens(&parsed, &source_text)
             }
-            FileType::TestsControl => tests::generate_semantic_tokens(&source_text),
+            FileType::TestsControl => {
+                let deb822_parse = workspace.get_parsed_deb822(file.source_file);
+                tests::generate_semantic_tokens(&deb822_parse, &source_text)
+            }
             FileType::UpstreamMetadata => upstream_metadata::generate_semantic_tokens(&source_text),
             // TODO: Implement semantic tokens for other file types
             _ => vec![],
@@ -671,7 +686,8 @@ impl LanguageServer for Backend {
                 watch::generate_folding_ranges(&parsed, &source_text)
             }
             FileType::TestsControl => {
-                match deb822_lossless::Deb822::parse(&source_text).to_result() {
+                let deb822_parse = workspace.get_parsed_deb822(file.source_file);
+                match deb822_parse.to_result() {
                     Ok(deb822) => deb822::folding::generate_folding_ranges(&deb822, &source_text),
                     Err(_) => return Ok(None),
                 }
@@ -866,6 +882,67 @@ mod main_tests {
 
         assert_eq!(FileType::detect(&changelog_uri), Some(FileType::Changelog));
         assert_eq!(FileType::detect(&control_uri), Some(FileType::Control));
+    }
+
+    #[test]
+    fn test_incremental_edit_apply() {
+        // Simulate applying an incremental edit like did_change does
+        let mut text = "Source: test\nMaintainer: Alice\n".to_string();
+        let range = Range::new(Position::new(0, 8), Position::new(0, 12));
+        let text_range = position::try_lsp_range_to_text_range(&text, &range).unwrap();
+        let start: usize = text_range.start().into();
+        let end: usize = text_range.end().into();
+        text.replace_range(start..end, "hello");
+        assert_eq!(text, "Source: hello\nMaintainer: Alice\n");
+    }
+
+    #[test]
+    fn test_incremental_edit_insert() {
+        let mut text = "Source: test\n".to_string();
+        // Insert at end of line 0
+        let range = Range::new(Position::new(0, 12), Position::new(0, 12));
+        let text_range = position::try_lsp_range_to_text_range(&text, &range).unwrap();
+        let start: usize = text_range.start().into();
+        let end: usize = text_range.end().into();
+        text.replace_range(start..end, "-pkg");
+        assert_eq!(text, "Source: test-pkg\n");
+    }
+
+    #[test]
+    fn test_incremental_edit_delete() {
+        let mut text = "Source: test-pkg\n".to_string();
+        let range = Range::new(Position::new(0, 8), Position::new(0, 16));
+        let text_range = position::try_lsp_range_to_text_range(&text, &range).unwrap();
+        let start: usize = text_range.start().into();
+        let end: usize = text_range.end().into();
+        text.replace_range(start..end, "");
+        assert_eq!(text, "Source: \n");
+    }
+
+    #[test]
+    fn test_incremental_edit_multiline() {
+        let mut text = "Source: test\nMaintainer: Alice\nPriority: optional\n".to_string();
+        // Replace entire second line
+        let range = Range::new(Position::new(1, 0), Position::new(2, 0));
+        let text_range = position::try_lsp_range_to_text_range(&text, &range).unwrap();
+        let start: usize = text_range.start().into();
+        let end: usize = text_range.end().into();
+        text.replace_range(start..end, "Maintainer: Bob\n");
+        assert_eq!(text, "Source: test\nMaintainer: Bob\nPriority: optional\n");
+    }
+
+    #[test]
+    fn test_workspace_update_file_reuses_input() {
+        let mut workspace = workspace::Workspace::new();
+        let url: Uri = str::parse("file:///debian/control").unwrap();
+
+        let file1 = workspace.update_file(url.clone(), "Source: a\n".to_string());
+        let file2 = workspace.update_file(url.clone(), "Source: b\n".to_string());
+
+        // Should reuse the same SourceFile input
+        assert_eq!(file1, file2);
+        // Text should be updated
+        assert_eq!(workspace.source_text(file2), "Source: b\n");
     }
 
     #[test]

--- a/src/tests/semantic.rs
+++ b/src/tests/semantic.rs
@@ -30,9 +30,11 @@ impl FieldValidator for TestsControlFieldValidator {
 }
 
 /// Generate semantic tokens for a debian/tests/control file
-pub fn generate_semantic_tokens(source_text: &str) -> Vec<SemanticToken> {
-    let parsed = deb822_lossless::Deb822::parse(source_text);
-    let deb822 = parsed.tree();
+pub fn generate_semantic_tokens(
+    deb822_parse: &deb822_lossless::Parse<deb822_lossless::Deb822>,
+    source_text: &str,
+) -> Vec<SemanticToken> {
+    let deb822 = deb822_parse.tree();
     let validator = TestsControlFieldValidator;
     generate_tokens(&deb822, source_text, &validator)
 }
@@ -45,7 +47,8 @@ mod tests {
     #[test]
     fn test_known_fields() {
         let text = "Tests: my-test\nDepends: @\nRestrictions: needs-root\n";
-        let tokens = generate_semantic_tokens(text);
+        let parsed = deb822_lossless::Deb822::parse(text);
+        let tokens = generate_semantic_tokens(&parsed, text);
 
         assert_eq!(tokens.len(), 6);
 
@@ -62,7 +65,8 @@ mod tests {
     #[test]
     fn test_unknown_field() {
         let text = "Tests: my-test\nX-Custom: value\n";
-        let tokens = generate_semantic_tokens(text);
+        let parsed = deb822_lossless::Deb822::parse(text);
+        let tokens = generate_semantic_tokens(&parsed, text);
 
         assert_eq!(tokens[2].token_type, TokenType::UnknownField as u32);
         assert_eq!(tokens[2].length, 8); // "X-Custom"
@@ -71,7 +75,8 @@ mod tests {
     #[test]
     fn test_case_insensitive() {
         let text = "tests: my-test\n";
-        let tokens = generate_semantic_tokens(text);
+        let parsed = deb822_lossless::Deb822::parse(text);
+        let tokens = generate_semantic_tokens(&parsed, text);
 
         assert_eq!(tokens[0].token_type, TokenType::Field as u32);
     }

--- a/src/watch/folding.rs
+++ b/src/watch/folding.rs
@@ -15,19 +15,13 @@ pub fn generate_folding_ranges(
     source_text: &str,
 ) -> Vec<FoldingRange> {
     match parse.to_watch_file() {
-        debian_watch::parse::ParsedWatchFile::Deb822(_) => {
-            generate_deb822_folding_ranges(source_text)
+        debian_watch::parse::ParsedWatchFile::Deb822(wf) => {
+            crate::deb822::folding::generate_folding_ranges(wf.as_deb822(), source_text)
         }
         debian_watch::parse::ParsedWatchFile::LineBased(wf) => {
             generate_linebased_folding_ranges(&wf, source_text)
         }
     }
-}
-
-fn generate_deb822_folding_ranges(source_text: &str) -> Vec<FoldingRange> {
-    let deb822_parse = deb822_lossless::Deb822::parse(source_text);
-    let deb822 = deb822_parse.tree();
-    crate::deb822::folding::generate_folding_ranges(&deb822, source_text)
 }
 
 fn generate_linebased_folding_ranges(

--- a/src/watch/semantic.rs
+++ b/src/watch/semantic.rs
@@ -22,19 +22,14 @@ pub fn generate_semantic_tokens(
     source_text: &str,
 ) -> Vec<SemanticToken> {
     match parse.to_watch_file() {
-        debian_watch::parse::ParsedWatchFile::Deb822(_) => generate_deb822_tokens(source_text),
+        debian_watch::parse::ParsedWatchFile::Deb822(wf) => {
+            let validator = WatchFieldValidator;
+            crate::deb822::semantic::generate_tokens(wf.as_deb822(), source_text, &validator)
+        }
         debian_watch::parse::ParsedWatchFile::LineBased(_) => {
             generate_linebased_tokens(source_text)
         }
     }
-}
-
-/// Generate tokens for v5 deb822 watch files
-fn generate_deb822_tokens(source_text: &str) -> Vec<SemanticToken> {
-    let deb822_parse = deb822_lossless::Deb822::parse(source_text);
-    let deb822 = deb822_parse.tree();
-    let validator = WatchFieldValidator;
-    crate::deb822::semantic::generate_tokens(&deb822, source_text, &validator)
 }
 
 /// Generate tokens for v1-4 line-based watch files

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use rowan::ast::AstNode;
+use salsa::Setter;
 use text_size::TextRange;
 use tower_lsp_server::ls_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Uri};
 
@@ -18,6 +21,7 @@ pub struct UnreleasedUploadInfo {
 }
 
 #[salsa::input]
+#[derive(Debug)]
 pub struct SourceFile {
     pub url: Uri,
     pub text: String,
@@ -57,11 +61,21 @@ pub fn parse_changelog(
     debian_changelog::ChangeLog::parse(&text)
 }
 
+#[salsa::tracked]
+pub fn parse_deb822(
+    db: &dyn salsa::Database,
+    file: SourceFile,
+) -> deb822_lossless::Parse<deb822_lossless::Deb822> {
+    let text = file.text(db);
+    deb822_lossless::Deb822::parse(&text)
+}
+
 // The actual database implementation
 #[salsa::db]
 #[derive(Clone, Default)]
 pub struct Workspace {
     storage: salsa::Storage<Self>,
+    files: HashMap<Uri, SourceFile>,
 }
 
 impl salsa::Database for Workspace {}
@@ -72,7 +86,14 @@ impl Workspace {
     }
 
     pub fn update_file(&mut self, url: Uri, text: String) -> SourceFile {
-        SourceFile::new(self, url, text)
+        if let Some(&existing) = self.files.get(&url) {
+            existing.set_text(self).to(text);
+            existing
+        } else {
+            let sf = SourceFile::new(self, url.clone(), text);
+            self.files.insert(url, sf);
+            sf
+        }
     }
 
     pub fn get_parsed_control(
@@ -218,6 +239,13 @@ impl Workspace {
 
     pub fn get_parsed_watch(&self, file: SourceFile) -> debian_watch::parse::Parse {
         parse_watch(self, file)
+    }
+
+    pub fn get_parsed_deb822(
+        &self,
+        file: SourceFile,
+    ) -> deb822_lossless::Parse<deb822_lossless::Deb822> {
+        parse_deb822(self, file)
     }
 
     pub fn get_parsed_changelog(


### PR DESCRIPTION
- Fix Salsa input reuse: update_file() now reuses existing SourceFile inputs via set_text() instead of creating new ones, so Salsa's memoization actually prevents re-parsing unchanged files.

- Switch to TextDocumentSyncKind::INCREMENTAL so the client sends only changed ranges rather than the full document on every keystroke.

- Use WatchFile::as_deb822() from debian-watch 0.4.6 to access the deb822 tree from the already-cached parse result, eliminating redundant re-parsing in watch semantic tokens, folding, and completion.

- Add parse_deb822 tracked function for tests/control files so their semantic tokens and folding ranges use the Salsa cache.

- Fix control completion to keep the workspace lock and parsed result in the sync path instead of dropping and re-acquiring them.