### PR TITLE
changelog: also match debian/changelog.dch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ augroup debian_filetypes
   autocmd BufNewFile,BufRead */debian/control setfiletype debcontrol
   autocmd BufNewFile,BufRead */debian/copyright setfiletype debcopyright
   autocmd BufNewFile,BufRead */debian/changelog setfiletype debchangelog
+  autocmd BufNewFile,BufRead */debian/changelog.dch setfiletype debchangelog
   autocmd BufNewFile,BufRead */debian/source/format setfiletype debsources
   autocmd BufNewFile,BufRead */debian/watch setfiletype debwatch
   autocmd BufNewFile,BufRead */debian/upstream/metadata setfiletype debupstream
@@ -195,6 +196,7 @@ vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
     '*/debian/control',
     '*/debian/copyright',
     '*/debian/changelog',
+    '*/debian/changelog.dch',
     '*/debian/source/format',
     '*/debian/watch',
     '*/debian/tests/control',

--- a/ale-debian-lsp.vim
+++ b/ale-debian-lsp.vim
@@ -103,6 +103,7 @@ augroup debian_filetypes
   autocmd BufNewFile,BufRead */debian/control setfiletype debcontrol
   autocmd BufNewFile,BufRead */debian/copyright setfiletype debcopyright
   autocmd BufNewFile,BufRead */debian/changelog setfiletype debchangelog
+  autocmd BufNewFile,BufRead */debian/changelog.dch setfiletype debchangelog
   autocmd BufNewFile,BufRead */debian/source/format setfiletype debsources
   autocmd BufNewFile,BufRead */debian/watch setfiletype debwatch
   autocmd BufNewFile,BufRead */debian/upstream/metadata setfiletype debupstream

--- a/coc-debian/src/index.ts
+++ b/coc-debian/src/index.ts
@@ -67,12 +67,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
       { scheme: 'file', pattern: '**/debian/tests/control' },
       { scheme: 'file', pattern: '**/debian/changelog' },
       { scheme: 'file', pattern: '**/changelog' },
+      { scheme: 'file', pattern: '**/debian/changelog.dch' },
+      { scheme: 'file', pattern: '**/changelog.dch' },
       { scheme: 'file', pattern: '**/debian/source/format' },
       { scheme: 'file', pattern: '**/debian/upstream/metadata' },
       { scheme: 'file', pattern: '**/debian/rules' }
     ],
     synchronize: {
-      fileEvents: workspace.createFileSystemWatcher('**/debian/{control,copyright,watch,changelog,tests/control,source/format,upstream/metadata,rules}')
+      fileEvents: workspace.createFileSystemWatcher('**/debian/{control,copyright,watch,changelog,changelog.dch,tests/control,source/format,upstream/metadata,rules}')
     }
   };
 

--- a/src/changelog/detection.rs
+++ b/src/changelog/detection.rs
@@ -3,7 +3,10 @@ use tower_lsp_server::ls_types::Uri;
 /// Check if a given URL represents a Debian changelog file
 pub fn is_changelog_file(uri: &Uri) -> bool {
     let path = uri.as_str();
-    path.ends_with("/changelog") || path.ends_with("/debian/changelog")
+    path.ends_with("/changelog")
+        || path.ends_with("/debian/changelog")
+        || path.ends_with("/changelog.dch")
+        || path.ends_with("/debian/changelog.dch")
 }
 
 #[cfg(test)]
@@ -17,6 +20,10 @@ mod tests {
             "file:///project/debian/changelog",
             "file:///changelog",
             "file:///some/path/changelog",
+            "file:///path/to/debian/changelog.dch",
+            "file:///project/debian/changelog.dch",
+            "file:///changelog.dch",
+            "file:///some/path/changelog.dch",
         ];
 
         let non_changelog_paths = vec![

--- a/vscode-debian/package.json
+++ b/vscode-debian/package.json
@@ -91,8 +91,12 @@
           "Debian Changelog",
           "debchangelog"
         ],
+        "extensions": [
+          ".dch"
+        ],
         "filenamePatterns": [
-          "**/debian/changelog"
+          "**/debian/changelog",
+          "**/debian/changelog.dch"
         ],
         "configuration": "./language-configuration.json"
       },


### PR DESCRIPTION
Add support for .dch extension across the LSP server detection, vscode/coc extensions, ALE config, and editor configuration snippets.