### PR TITLE
changelog: make "Add new changelog entry" a file-wide source action

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -617,13 +617,14 @@ impl LanguageServer for Backend {
 
         let mut actions = Vec::new();
 
-        // Check for field casing issues - only process fields in the requested range
-        let Some(text_range) = try_lsp_range_to_text_range(&source_text, &params.range) else {
-            return Ok(None);
-        };
+        let text_range = try_lsp_range_to_text_range(&source_text, &params.range);
 
         match file_info.file_type {
             FileType::Control => {
+                let Some(text_range) = text_range else {
+                    return Ok(None);
+                };
+
                 // Add wrap-and-sort action
                 let parsed = workspace.get_parsed_control(file_info.source_file);
                 if let Some(action) = control::get_wrap_and_sort_action(
@@ -646,6 +647,10 @@ impl LanguageServer for Backend {
                 ));
             }
             FileType::Copyright => {
+                let Some(text_range) = text_range else {
+                    return Ok(None);
+                };
+
                 // Add wrap-and-sort action
                 let parsed = workspace.get_parsed_copyright(file_info.source_file);
                 if let Some(action) = copyright::get_wrap_and_sort_action(
@@ -668,7 +673,7 @@ impl LanguageServer for Backend {
                 ));
             }
             FileType::Changelog => {
-                // Add action to create a new changelog entry
+                // Add action to create a new changelog entry (file-wide action)
                 let parsed = workspace.get_parsed_changelog(file_info.source_file);
                 let changelog = parsed.tree();
                 match changelog::generate_new_changelog_entry(&changelog) {
@@ -699,7 +704,7 @@ impl LanguageServer for Backend {
 
                         let action = CodeAction {
                             title: "Add new changelog entry".to_string(),
-                            kind: Some(CodeActionKind::REFACTOR),
+                            kind: Some(CodeActionKind::SOURCE),
                             edit: Some(workspace_edit),
                             ..Default::default()
                         };
@@ -712,34 +717,37 @@ impl LanguageServer for Backend {
                 }
 
                 // Check for UNRELEASED entries in the requested range and offer "Mark for upload"
-                let unreleased_entries =
-                    workspace.find_unreleased_entries_in_range(file_info.source_file, text_range);
+                if let Some(text_range) = text_range {
+                    let unreleased_entries = workspace
+                        .find_unreleased_entries_in_range(file_info.source_file, text_range);
 
-                for info in unreleased_entries {
-                    let lsp_range = text_range_to_lsp_range(&source_text, info.unreleased_range);
+                    for info in unreleased_entries {
+                        let lsp_range =
+                            text_range_to_lsp_range(&source_text, info.unreleased_range);
 
-                    let edit = TextEdit {
-                        range: lsp_range,
-                        new_text: info.target_distribution.clone(),
-                    };
+                        let edit = TextEdit {
+                            range: lsp_range,
+                            new_text: info.target_distribution.clone(),
+                        };
 
-                    let workspace_edit = WorkspaceEdit {
-                        changes: Some(
-                            vec![(params.text_document.uri.clone(), vec![edit])]
-                                .into_iter()
-                                .collect(),
-                        ),
-                        ..Default::default()
-                    };
+                        let workspace_edit = WorkspaceEdit {
+                            changes: Some(
+                                vec![(params.text_document.uri.clone(), vec![edit])]
+                                    .into_iter()
+                                    .collect(),
+                            ),
+                            ..Default::default()
+                        };
 
-                    let action = CodeAction {
-                        title: format!("Mark for upload to {}", info.target_distribution),
-                        kind: Some(CodeActionKind::REFACTOR),
-                        edit: Some(workspace_edit),
-                        ..Default::default()
-                    };
+                        let action = CodeAction {
+                            title: format!("Mark for upload to {}", info.target_distribution),
+                            kind: Some(CodeActionKind::REFACTOR),
+                            edit: Some(workspace_edit),
+                            ..Default::default()
+                        };
 
-                    actions.push(CodeActionOrCommand::CodeAction(action));
+                        actions.push(CodeActionOrCommand::CodeAction(action));
+                    }
                 }
             }
             _ => unreachable!(),


### PR DESCRIPTION
Change the action kind from REFACTOR to SOURCE so it appears regardless of cursor position. The action always inserts at the top of the file and doesn't depend on the selected range.