### PR TITLE
Completion for patches/series

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -674,6 +674,7 @@ dependencies = [
  "launchpadlib",
  "lintian-overrides",
  "makefile-lossless",
+ "patchkit",
  "rowan",
  "salsa",
  "serde",
@@ -869,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1155,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1250,6 +1251,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,9 +1301,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1304,7 +1315,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1377,12 +1387,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1390,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1403,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1417,15 +1428,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1437,15 +1448,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1485,12 +1496,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1506,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1521,9 +1532,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1611,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1684,9 +1695,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1696,14 +1707,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1735,9 +1746,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1824,9 +1835,9 @@ dependencies = [
  "log",
  "phf 0.10.1",
  "phf_codegen 0.10.0",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
 ]
 
 [[package]]
@@ -1838,9 +1849,20 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -1851,7 +1873,7 @@ checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
 dependencies = [
  "html5ever 0.26.0",
  "markup5ever 0.11.0",
- "tendril",
+ "tendril 0.4.3",
  "xml5ever 0.17.0",
 ]
 
@@ -1863,7 +1885,7 @@ checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
 dependencies = [
  "html5ever 0.27.0",
  "markup5ever 0.12.1",
- "tendril",
+ "tendril 0.4.3",
  "xml5ever 0.18.1",
 ]
 
@@ -2095,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "patchkit"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21e87e02a475262c3166d32fea34710510448b37117cc448c1be03975816baf"
+checksum = "d5364f5b47b05204e0eb3e5427657769dd1924f4ec3e2b823c0575546049439a"
 dependencies = [
  "chrono",
  "lazy-regex",
@@ -2185,6 +2207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2234,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2225,6 +2267,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,16 +2295,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -2295,9 +2350,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2357,9 +2412,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "chrono",
  "libc",
@@ -2373,18 +2428,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2401,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2413,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2597,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2988,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3053,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3412,6 +3467,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3486,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -3552,6 +3631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
 
 [[package]]
 name = "thiserror"
@@ -3625,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3650,9 +3739,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3667,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3747,18 +3836,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3984,7 +4073,7 @@ dependencies = [
  "debian-watch",
  "debversion",
  "futures",
- "html5ever 0.27.0",
+ "html5ever 0.39.0",
  "lazy-regex",
  "lazy_static",
  "log",
@@ -4005,7 +4094,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shlex",
- "tendril",
+ "tendril 0.5.0",
  "textwrap",
  "tokio",
  "url",
@@ -4134,9 +4223,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4147,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4157,9 +4246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4167,9 +4256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4180,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4223,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4239,6 +4328,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -4267,7 +4368,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4636,9 +4737,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -4730,9 +4831,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xml"
@@ -4789,9 +4890,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4800,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4812,18 +4913,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4832,18 +4933,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4859,9 +4960,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4870,9 +4971,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4881,9 +4982,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 salsa = ">=0.23, <0.27"
 text-size = "1.1"
+patchkit = "0.2.4"
 launchpadlib = { version = "0.5.7", optional = true, default-features = false, features = ["async", "api-v1_0", "bugs", "packages"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Language Server Protocol implementation for Debian packaging files.
 - `debian/tests/control` - Autopkgtest control files (basic support)
 - `debian/upstream/metadata` - DEP-12 upstream metadata files
 - `debian/rules` - Package build rules (Makefile)
+- `debian/patches/series` - List of patches applied by dpkg-source
 
 ## Features
 
@@ -55,6 +56,11 @@ Language Server Protocol implementation for Debian packaging files.
 - Target name completions for standard Debian Policy targets (clean, build, binary, etc.) and debhelper override/execute targets
 - Variable name completions for common build variables (DEB_BUILD_OPTIONS, DEB_HOST_MULTIARCH, etc.)
 - Excludes already-defined targets from completions
+
+**debian/patches/series:**
+- Patch name completions based on files present in the `debian/patches/` directory
+- Package name completions for patch entries, excluding already listed patches
+- Option value completions for patch application flags (`-p0`, `-p1`, `-p2`, etc.)
 
 ### Diagnostics
 
@@ -170,7 +176,7 @@ function! s:config_debian_lsp()
       autocmd User lsp_setup call lsp#register_server({
         \ 'name': 'debian-lsp',
         \ 'cmd': {server_info -> ['debian-lsp']},
-        \ 'allowlist': ['debcontrol', 'debcopyright', 'debchangelog', 'debsources', 'debsourceoptions', 'debwatch', 'debupstream', 'autopkgtest', 'debrules'],
+        \ 'allowlist': ['debcontrol', 'debcopyright', 'debchangelog', 'debsources', 'debsourceoptions', 'debwatch', 'debupstream', 'autopkgtest', 'debrules', 'debpatches'],
         \ 'blocklist': [],
         \ 'enabled': 1,
         \ })
@@ -193,6 +199,7 @@ augroup debian_filetypes
   autocmd BufNewFile,BufRead */debian/watch setfiletype debwatch
   autocmd BufNewFile,BufRead */debian/upstream/metadata setfiletype debupstream
   autocmd BufNewFile,BufRead */debian/rules setfiletype debrules
+  autocmd BufNewFile,BufRead */debian/patches/series setfiletype debpatches
 augroup END
 ```
 
@@ -246,6 +253,7 @@ vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
     '*/debian/tests/control',
     '*/debian/upstream/metadata',
     '*/debian/rules',
+    '*/debian/patches/series',
   },
   callback = function()
     vim.lsp.start({

--- a/ale-debian-lsp.vim
+++ b/ale-debian-lsp.vim
@@ -23,6 +23,7 @@ let g:ale_linters.debwatch = ['debian-lsp']
 let g:ale_linters.debupstream = ['debian-lsp']
 let g:ale_linters.autopkgtest = ['debian-lsp']
 let g:ale_linters.debrules = ['debian-lsp']
+let g:ale_linters.debpatches = ['debian-lsp']
 
 " Define debian-lsp for debian/control files
 call ale#linter#Define('debcontrol', {
@@ -105,6 +106,16 @@ call ale#linter#Define('autopkgtest', {
 \   'project_root': function('ale#handlers#lsp#GetProjectRoot'),
 \})
 
+" Define debian-lsp for debian/patches/series files
+call ale#linter#Define('debpatches', {
+\   'name': 'debian-lsp',
+\   'lsp': 'stdio',
+\   'executable': g:debian_lsp_executable,
+\   'command': '%e',
+\   'project_root': function('ale#handlers#lsp#GetProjectRoot'),
+\})
+
+
 " Set filetypes for Debian packaging files
 " Note: Vim already detects debcontrol, debcopyright, debchangelog,
 " debsources, and autopkgtest.
@@ -120,4 +131,5 @@ augroup debian_filetypes
   autocmd BufNewFile,BufRead */debian/watch setfiletype debwatch
   autocmd BufNewFile,BufRead */debian/upstream/metadata setfiletype debupstream
   autocmd BufNewFile,BufRead */debian/rules setfiletype debrules
+  autocmd BufNewFile,BufRead */debian/patches/series setfiletype debpatches
 augroup END

--- a/coc-debian/package.json
+++ b/coc-debian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-debian",
   "version": "0.1.7",
-  "description": "Debian language server support for coc.nvim (control, copyright, watch, changelog, tests/control, source/format, source/options, upstream/metadata, rules)",
+  "description": "Debian language server support for coc.nvim (control, copyright, watch, changelog, tests/control, source/format, source/options, upstream/metadata, rules, patches/series)",
   "main": "lib/index.js",
   "engines": {
     "coc": "^0.0.80"

--- a/coc-debian/src/index.ts
+++ b/coc-debian/src/index.ts
@@ -61,6 +61,7 @@ function setupFiletypeDetection(context: ExtensionContext): void {
     ['*/debian/source/local-options', 'debsourceoptions'],
     ['*/debian/upstream/metadata', 'debupstream'],
     ['*/debian/rules', 'debrules'],
+    ['*/debian/patches/series', 'debpatches'],
   ];
 
   for (const [pattern, filetype] of filetypeMap) {
@@ -106,6 +107,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       { language: 'debsourceoptions' },
       { language: 'debupstream' },
       { language: 'debrules' },
+      { language: 'debpatches' },
       { scheme: 'file', pattern: '**/debian/control' },
       { scheme: 'file', pattern: '**/debian/copyright' },
       { scheme: 'file', pattern: '**/debian/watch' },
@@ -117,12 +119,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
       { scheme: 'file', pattern: '**/debian/source/local-options' },
       { scheme: 'file', pattern: '**/debian/upstream/metadata' },
       { scheme: 'file', pattern: '**/debian/rules' },
+      { scheme: 'file', pattern: '**/debian/patches/series' },
     ],
     initializationOptions: {
       upstreamOntologistNetAccess: config.get<boolean>('upstreamOntologistNetAccess', false),
     },
     synchronize: {
-      fileEvents: workspace.createFileSystemWatcher('**/debian/{control,copyright,watch,changelog,changelog.dch,tests/control,source/format,source/options,source/local-options,upstream/metadata,rules}')
+      fileEvents: workspace.createFileSystemWatcher('**/debian/{control,copyright,watch,changelog,changelog.dch,tests/control,source/format,source/options,source/local-options,upstream/metadata,rules,patches/series}')
     }
   };
 

--- a/emacs-lspconfig/README.md
+++ b/emacs-lspconfig/README.md
@@ -61,6 +61,7 @@ Add the following configuration:
 (define-derived-mode debsources-mode       fundamental-mode "debsources")
 (define-derived-mode debsourceoptions-mode fundamental-mode "debsourceoptions")
 (define-derived-mode debupstream-mode      fundamental-mode "debupstream")
+(define-derived-mode debpatches-mode       fundamental-mode "debpatches")
 (define-derived-mode autopkgtest-mode      fundamental-mode "autopkgtest")
 
 ;; Associate Debian packaging files with their modes
@@ -74,6 +75,7 @@ Add the following configuration:
 (add-to-list 'auto-mode-alist '("debian/source/options\\'"       . debsourceoptions-mode))
 (add-to-list 'auto-mode-alist '("debian/source/local-options\\'" . debsourceoptions-mode))
 (add-to-list 'auto-mode-alist '("debian/upstream/metadata\\'"    . debupstream-mode))
+(add-to-list 'auto-mode-alist '("debian/patches/series\\'"      . debpatches-mode))
 (add-to-list 'auto-mode-alist '("debian/tests/control\\'"        . autopkgtest-mode))
 
 ;; Register debian-lsp and enable company for all Debian modes
@@ -85,6 +87,7 @@ Add the following configuration:
                 debsources-mode
                 debsourceoptions-mode
                 debupstream-mode
+                debpatches-mode
                 autopkgtest-mode))
   (add-to-list 'eglot-server-programs
                `(,mode . ("debian-lsp")))

--- a/helix-lspconfig/README.md
+++ b/helix-lspconfig/README.md
@@ -86,6 +86,14 @@ language-servers = ["debian-lsp"]
 comment-tokens = "#"
 
 [[language]]
+name = "debseries"
+scope = "text.debian.series"
+file-types = [{ glob = "debian/patches/series"}]
+language-servers = ["debian-lsp"]
+comment-tokens = "#"
+
+
+[[language]]
 name = "debian"
 language-servers = ["debian-lsp"]
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,8 +701,9 @@ impl LanguageServer for Backend {
             }
             Some((FileType::PatchesSeries, source_file)) => {
                 let workspace = self.workspace.lock().await;
+                let source_text = workspace.source_text(source_file);
                 let parsed = workspace.get_parsed_patches_series(source_file);
-                patches_series::get_completions(&uri, &parsed)
+                patches_series::get_completions(&uri, &parsed, &source_text, position)
             }
             None => Vec::new(),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod distros;
 mod lintian_overrides;
 mod maintainers;
 mod package_cache;
+mod patches_series;
 mod popcon;
 mod position;
 mod rdeps;
@@ -87,6 +88,8 @@ enum FileType {
     Rules,
     /// lintian overrides file (debian/source/lintian-overrides or debian/*.lintian-overrides)
     LintianOverrides,
+    /// debian/patches/series file
+    PatchesSeries,
 }
 
 impl FileType {
@@ -112,6 +115,8 @@ impl FileType {
             Some(Self::Rules)
         } else if lintian_overrides::is_lintian_overrides_file(uri) {
             Some(Self::LintianOverrides)
+        } else if patches_series::is_patches_series_file(uri) {
+            Some(Self::PatchesSeries)
         } else {
             None
         }
@@ -164,7 +169,8 @@ impl Backend {
             | FileType::SourceOptions
             | FileType::UpstreamMetadata
             | FileType::Rules
-            | FileType::LintianOverrides => None,
+            | FileType::LintianOverrides
+            | FileType::PatchesSeries => None,
         }
     }
 
@@ -693,6 +699,11 @@ impl LanguageServer for Backend {
                 let makefile = parsed.tree();
                 rules::get_completions(&makefile, &source_text, position)
             }
+            Some((FileType::PatchesSeries, source_file)) => {
+                let workspace = self.workspace.lock().await;
+                let parsed = workspace.get_parsed_patches_series(source_file);
+                patches_series::get_completions(&uri, &parsed)
+            }
             None => Vec::new(),
         };
 
@@ -1072,6 +1083,7 @@ impl LanguageServer for Backend {
                     Err(_) => vec![],
                 }
             }
+            FileType::PatchesSeries => vec![],
         };
 
         if tokens.is_empty() {

--- a/src/patches_series/completion.rs
+++ b/src/patches_series/completion.rs
@@ -1,0 +1,146 @@
+use super::detection::list_patch_files;
+use std::collections::HashSet;
+
+use tower_lsp_server::ls_types::{CompletionItem, CompletionItemKind, Uri};
+
+/// Get completion items for a debian/patches/series file
+pub fn get_completions(
+    uri: &Uri,
+    parsed: &patchkit::edit::Parse<patchkit::edit::series::lossless::SeriesFile>,
+) -> Vec<CompletionItem> {
+    let series = parsed.tree();
+
+    let already_listed: HashSet<String> = series.patch_entries().filter_map(|e| e.name()).collect();
+    let patch_files = list_patch_files(uri);
+    get_patch_file_completions(&patch_files, &already_listed)
+}
+
+// Get snippet completions for each patches in the debian/patches folder
+fn get_patch_file_completions(
+    patch_files: &HashSet<String>,
+    already_listed: &HashSet<String>,
+) -> Vec<CompletionItem> {
+    let mut items: Vec<CompletionItem> = patch_files
+        .iter()
+        .filter(|name| !already_listed.contains(*name))
+        .map(|name| CompletionItem {
+            label: name.clone(),
+            kind: Some(CompletionItemKind::FILE),
+            detail: Some("Patch file".to_string()),
+            ..Default::default()
+        })
+        .collect();
+
+    items.sort_by(|a, b| a.label.cmp(&b.label));
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use patchkit::quilt::{Series, SeriesEntry};
+
+    fn make_series(patches: &[&str]) -> Series {
+        Series {
+            entries: patches
+                .iter()
+                .map(|name| SeriesEntry::Patch {
+                    name: name.to_string(),
+                    options: vec![],
+                })
+                .collect(),
+        }
+    }
+
+    fn empty_series() -> Series {
+        Series { entries: vec![] }
+    }
+
+    #[test]
+    fn test_no_completions_when_two_tokens() {
+        let series = make_series(&["fix-arm.patch"]);
+        let source_text = "fix-arm.patch -p1";
+        let position = Position::new(0, 17);
+        let uri: Uri = "file:///debian/patches/series".parse().unwrap();
+
+        let completions = get_completions(&uri, &series, source_text, position);
+        assert!(completions.is_empty());
+    }
+
+    #[test]
+    fn test_no_completions_when_patch_and_option_present() {
+        let series = make_series(&["fix-arm.patch"]);
+        let source_text = "fix-arm.patch -p1 ";
+        let position = Position::new(0, 18);
+        let uri: Uri = "file:///debian/patches/series".parse().unwrap();
+
+        let completions = get_completions(&uri, &series, source_text, position);
+        assert!(completions.is_empty());
+    }
+
+    #[test]
+    fn test_patch_file_completions_excludes_already_listed() {
+        let patch_files: HashSet<String> = vec![
+            "fix-arm.patch".to_string(),
+            "fix-mips.patch".to_string(),
+            "CVE-2024.patch".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        let already_listed: HashSet<&str> = vec!["fix-arm.patch"].into_iter().collect();
+
+        let completions = get_patch_file_completions(&patch_files, &already_listed);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+        assert!(!labels.contains(&"fix-arm.patch"));
+        assert!(labels.contains(&"fix-mips.patch"));
+        assert!(labels.contains(&"CVE-2024.patch"));
+    }
+
+    #[test]
+    fn test_patch_file_completions_sorted() {
+        let patch_files: HashSet<String> = vec![
+            "zzz.patch".to_string(),
+            "aaa.patch".to_string(),
+            "mmm.patch".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        let already_listed: HashSet<&str> = HashSet::new();
+
+        let completions = get_patch_file_completions(&patch_files, &already_listed);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+        assert_eq!(labels, vec!["aaa.patch", "mmm.patch", "zzz.patch"]);
+    }
+
+    #[test]
+    fn test_patch_file_completions_have_file_kind() {
+        let patch_files: HashSet<String> = vec!["fix-arm.patch".to_string()].into_iter().collect();
+
+        let already_listed: HashSet<&str> = HashSet::new();
+
+        let completions = get_patch_file_completions(&patch_files, &already_listed);
+
+        assert!(completions
+            .iter()
+            .all(|c| c.kind == Some(CompletionItemKind::FILE)));
+    }
+
+    #[test]
+    fn test_patch_file_completions_all_listed_returns_empty() {
+        let patch_files: HashSet<String> =
+            vec!["fix-arm.patch".to_string(), "fix-mips.patch".to_string()]
+                .into_iter()
+                .collect();
+
+        let already_listed: HashSet<&str> = vec!["fix-arm.patch", "fix-mips.patch"]
+            .into_iter()
+            .collect();
+
+        let completions = get_patch_file_completions(&patch_files, &already_listed);
+        assert!(completions.is_empty());
+    }
+}

--- a/src/patches_series/completion.rs
+++ b/src/patches_series/completion.rs
@@ -1,16 +1,34 @@
 use super::detection::list_patch_files;
 use std::collections::HashSet;
 
-use tower_lsp_server::ls_types::{CompletionItem, CompletionItemKind, Uri};
+use tower_lsp_server::ls_types::{CompletionItem, CompletionItemKind, Position, Uri};
 
 /// Get completion items for a debian/patches/series file
 pub fn get_completions(
     uri: &Uri,
     parsed: &patchkit::edit::Parse<patchkit::edit::series::lossless::SeriesFile>,
+    source_text: &str,
+    position: Position,
 ) -> Vec<CompletionItem> {
     let series = parsed.tree();
 
+    let current_line = source_text
+        .lines()
+        .nth(position.line as usize)
+        .unwrap_or("");
+    let before_cursor = &current_line[..position.character as usize];
+    let tokens: Vec<&str> = before_cursor.split_whitespace().collect();
+
+    if tokens.len() >= 2 {
+        return Vec::new();
+    }
+
+    if tokens.len() == 1 && before_cursor.ends_with(' ') {
+        return get_strip_option_completions(tokens[0]);
+    }
+
     let already_listed: HashSet<String> = series.patch_entries().filter_map(|e| e.name()).collect();
+
     let patch_files = list_patch_files(uri);
     get_patch_file_completions(&patch_files, &already_listed)
 }
@@ -35,46 +53,136 @@ fn get_patch_file_completions(
     items
 }
 
+/// Get completion items for the strip option (-p0, -p1, -p2...)
+fn get_strip_option_completions(patch: &str) -> Vec<CompletionItem> {
+    let count = patch.split('/').count() - 1;
+    (0..=count)
+        .map(|n| {
+            let label = format!("-p{}", n);
+            CompletionItem {
+                label: label.clone(),
+                kind: Some(CompletionItemKind::VALUE),
+                detail: Some(format!("Strip {} path segment(s)", n)),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use patchkit::quilt::{Series, SeriesEntry};
 
-    fn make_series(patches: &[&str]) -> Series {
-        Series {
-            entries: patches
-                .iter()
-                .map(|name| SeriesEntry::Patch {
-                    name: name.to_string(),
-                    options: vec![],
-                })
-                .collect(),
+    fn make_series(
+        patches: &[&str],
+    ) -> patchkit::edit::Parse<patchkit::edit::series::lossless::SeriesFile> {
+        let text = patches.join("\n") + "\n";
+        patchkit::edit::series::parse(&text)
+    }
+
+    fn empty_series() -> patchkit::edit::Parse<patchkit::edit::series::lossless::SeriesFile> {
+        patchkit::edit::series::parse("")
+    }
+
+    #[test]
+    fn test_strip_option_completions_no_slash() {
+        let completions = get_strip_option_completions("fix-arm.patch");
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert_eq!(labels, vec!["-p0"]);
+        assert_eq!(completions.len(), 1);
+    }
+
+    #[test]
+    fn test_strip_option_completions_one_slash() {
+        let completions = get_strip_option_completions("upstream/fix-arm.patch");
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert_eq!(labels, vec!["-p0", "-p1"]);
+        assert_eq!(completions.len(), 2);
+    }
+
+    #[test]
+    fn test_strip_option_completions_two_slashes() {
+        let completions = get_strip_option_completions("a/b/fix.patch");
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert_eq!(labels, vec!["-p0", "-p1", "-p2"]);
+        assert_eq!(completions.len(), 3);
+    }
+
+    #[test]
+    fn test_strip_option_completions_have_details() {
+        let completions = get_strip_option_completions("fix-arm.patch");
+        for c in &completions {
+            assert!(c.detail.is_some());
         }
     }
 
-    fn empty_series() -> Series {
-        Series { entries: vec![] }
+    #[test]
+    fn test_strip_option_completions_detail_format() {
+        let completions = get_strip_option_completions("upstream/fix-arm.patch");
+        for (i, c) in completions.iter().enumerate() {
+            assert_eq!(
+                c.detail.as_deref(),
+                Some(format!("Strip {} path segment(s)", i).as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn test_strip_option_completions_kind() {
+        let completions = get_strip_option_completions("fix-arm.patch");
+        assert!(completions
+            .iter()
+            .all(|c| c.kind == Some(CompletionItemKind::VALUE)));
+    }
+
+    #[test]
+    fn test_strip_options_after_space() {
+        let parsed = make_series(&["fix-arm.patch"]);
+        let source_text = "fix-arm.patch ";
+        let position = Position::new(0, 14);
+        let uri: Uri = "file:///debian/patches/series".parse().unwrap();
+
+        let completions = get_completions(&uri, &parsed, source_text, position);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+        assert_eq!(labels, vec!["-p0"]);
+        assert!(completions
+            .iter()
+            .all(|c| c.kind == Some(CompletionItemKind::VALUE)));
+    }
+
+    #[test]
+    fn test_strip_options_after_space_subdir() {
+        let parsed = make_series(&["upstream/fix-arm.patch"]);
+        let source_text = "upstream/fix-arm.patch ";
+        let position = Position::new(0, 23);
+        let uri: Uri = "file:///debian/patches/series".parse().unwrap();
+
+        let completions = get_completions(&uri, &parsed, source_text, position);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+        assert_eq!(labels, vec!["-p0", "-p1"]);
     }
 
     #[test]
     fn test_no_completions_when_two_tokens() {
-        let series = make_series(&["fix-arm.patch"]);
+        let parsed = make_series(&["fix-arm.patch"]);
         let source_text = "fix-arm.patch -p1";
         let position = Position::new(0, 17);
         let uri: Uri = "file:///debian/patches/series".parse().unwrap();
 
-        let completions = get_completions(&uri, &series, source_text, position);
+        let completions = get_completions(&uri, &parsed, source_text, position);
         assert!(completions.is_empty());
     }
 
     #[test]
     fn test_no_completions_when_patch_and_option_present() {
-        let series = make_series(&["fix-arm.patch"]);
+        let parsed = make_series(&["fix-arm.patch"]);
         let source_text = "fix-arm.patch -p1 ";
         let position = Position::new(0, 18);
         let uri: Uri = "file:///debian/patches/series".parse().unwrap();
 
-        let completions = get_completions(&uri, &series, source_text, position);
+        let completions = get_completions(&uri, &parsed, source_text, position);
         assert!(completions.is_empty());
     }
 
@@ -88,7 +196,8 @@ mod tests {
         .into_iter()
         .collect();
 
-        let already_listed: HashSet<&str> = vec!["fix-arm.patch"].into_iter().collect();
+        let already_listed: HashSet<String> =
+            vec!["fix-arm.patch".to_string()].into_iter().collect();
 
         let completions = get_patch_file_completions(&patch_files, &already_listed);
         let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
@@ -108,7 +217,7 @@ mod tests {
         .into_iter()
         .collect();
 
-        let already_listed: HashSet<&str> = HashSet::new();
+        let already_listed: HashSet<String> = HashSet::new();
 
         let completions = get_patch_file_completions(&patch_files, &already_listed);
         let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
@@ -120,7 +229,7 @@ mod tests {
     fn test_patch_file_completions_have_file_kind() {
         let patch_files: HashSet<String> = vec!["fix-arm.patch".to_string()].into_iter().collect();
 
-        let already_listed: HashSet<&str> = HashSet::new();
+        let already_listed: HashSet<String> = HashSet::new();
 
         let completions = get_patch_file_completions(&patch_files, &already_listed);
 
@@ -136,11 +245,27 @@ mod tests {
                 .into_iter()
                 .collect();
 
-        let already_listed: HashSet<&str> = vec!["fix-arm.patch", "fix-mips.patch"]
-            .into_iter()
-            .collect();
+        let already_listed: HashSet<String> =
+            vec!["fix-arm.patch".to_string(), "fix-mips.patch".to_string()]
+                .into_iter()
+                .collect();
 
         let completions = get_patch_file_completions(&patch_files, &already_listed);
         assert!(completions.is_empty());
+    }
+
+    #[test]
+    fn test_no_strip_options_without_space() {
+        let parsed = empty_series();
+        let source_text = "fix-arm";
+        let position = Position::new(0, 7);
+        let uri: Uri = "file:///debian/patches/series".parse().unwrap();
+
+        let completions = get_completions(&uri, &parsed, source_text, position);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+        assert!(!labels.contains(&"-p0"));
+        assert!(!labels.contains(&"-p1"));
+        assert!(!labels.contains(&"-p2"));
     }
 }

--- a/src/patches_series/detection.rs
+++ b/src/patches_series/detection.rs
@@ -1,0 +1,165 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use tower_lsp_server::ls_types::Uri;
+
+/// Check if a given URL represents a Debian patches/series file
+pub fn is_patches_series_file(uri: &Uri) -> bool {
+    let path = uri.as_str();
+    path.ends_with("/debian/patches/series")
+}
+
+// Get all files in a debian/patches folder
+pub fn list_patch_files(uri: &Uri) -> HashSet<String> {
+    let Some(path) = uri.to_file_path() else {
+        return HashSet::new();
+    };
+    let Some(patches_dir) = path.parent() else {
+        return HashSet::new();
+    };
+    let patches_dir = patches_dir.to_path_buf();
+    let mut result = HashSet::new();
+    collect_patches(&patches_dir, &patches_dir, &mut result);
+    result
+}
+
+fn collect_patches(base: &Path, dir: &Path, result: &mut HashSet<String>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_patches(base, &path, result);
+            } else {
+                if path.file_name().and_then(|n| n.to_str()) == Some("series") {
+                    continue;
+                }
+                if let Ok(relative) = path.strip_prefix(base) {
+                    if let Some(s) = relative.to_str() {
+                        result.insert(s.to_string());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_patches_series_file() {
+        let tests_patches_series_paths = vec![
+            "file:///path/to/debian/patches/series",
+            "file:///project/debian/patches/series",
+        ];
+        let non_tests_patches_series_paths = vec![
+            "file:///path/to/other.txt",
+            "file:///path/to/debian/control",
+            "file:///path/to/debian/copyright",
+            "file:///path/to/debian/watch",
+            "file:///path/to/patches/series", // Not in debian/ directory
+            "file:///path/to/debian/tests/control.backup",
+        ];
+        for path in tests_patches_series_paths {
+            let uri = path.parse::<Uri>().unwrap();
+            assert!(
+                is_patches_series_file(&uri),
+                "Should detect tests/patches/series file: {}",
+                path
+            );
+        }
+        for path in non_tests_patches_series_paths {
+            let uri = path.parse::<Uri>().unwrap();
+            assert!(
+                !is_patches_series_file(&uri),
+                "Should not detect as tests/patches/series file: {}",
+                path
+            );
+        }
+    }
+
+    #[test]
+    fn test_collect_patches_excludes_series_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        std::fs::write(base.join("fix-arm.patch"), "").unwrap();
+        std::fs::write(base.join("fix-mips.diff"), "").unwrap();
+        std::fs::write(base.join("fix-no-extension"), "").unwrap();
+        std::fs::write(base.join("series"), "").unwrap(); // doit être exclu
+
+        let mut result = std::collections::HashSet::new();
+        collect_patches(base, base, &mut result);
+
+        assert!(result.contains("fix-arm.patch"));
+        assert!(result.contains("fix-mips.diff"));
+        assert!(result.contains("fix-no-extension"));
+        assert!(!result.contains("series")); // series exclu ✓
+    }
+
+    #[test]
+    fn test_collect_patches_recursive() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        std::fs::create_dir(base.join("upstream")).unwrap();
+        std::fs::write(base.join("fix-arm.patch"), "").unwrap();
+        std::fs::write(base.join("upstream").join("fix-leak.patch"), "").unwrap();
+        std::fs::write(base.join("upstream").join("fix-mem.diff"), "").unwrap();
+
+        let mut result = std::collections::HashSet::new();
+        collect_patches(base, base, &mut result);
+
+        assert!(result.contains("fix-arm.patch"));
+        assert!(result.contains(
+            &std::path::Path::new("upstream")
+                .join("fix-leak.patch")
+                .to_string_lossy()
+                .to_string()
+        ));
+        assert!(result.contains(
+            &std::path::Path::new("upstream")
+                .join("fix-mem.diff")
+                .to_string_lossy()
+                .to_string()
+        ));
+    }
+
+    #[test]
+    fn test_collect_patches_accepts_diff_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        std::fs::write(base.join("fix-arm.diff"), "").unwrap();
+
+        let mut result = std::collections::HashSet::new();
+        collect_patches(base, base, &mut result);
+
+        assert!(result.contains("fix-arm.diff"));
+    }
+
+    #[test]
+    fn test_collect_patches_accepts_no_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        std::fs::write(base.join("001-fix-build"), "").unwrap();
+
+        let mut result = std::collections::HashSet::new();
+        collect_patches(base, base, &mut result);
+
+        assert!(result.contains("001-fix-build"));
+    }
+
+    #[test]
+    fn test_collect_patches_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+
+        let mut result = std::collections::HashSet::new();
+        collect_patches(base, base, &mut result);
+
+        assert!(result.is_empty());
+    }
+}

--- a/src/patches_series/mod.rs
+++ b/src/patches_series/mod.rs
@@ -1,0 +1,7 @@
+//! Module for handling debian/patches/series files
+
+pub mod completion;
+pub mod detection;
+
+pub use completion::*;
+pub use detection::is_patches_series_file;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -88,6 +88,15 @@ pub fn parse_upstream_metadata(
     yaml_edit::YamlFile::parse(&text)
 }
 
+#[salsa::tracked]
+pub fn parse_patches_series(
+    db: &dyn salsa::Database,
+    file: SourceFile,
+) -> patchkit::edit::Parse<patchkit::edit::series::lossless::SeriesFile> {
+    let text = file.text(db);
+    patchkit::edit::series::parse(&text)
+}
+
 // The actual database implementation
 #[salsa::db]
 #[derive(Clone, Default)]
@@ -285,6 +294,13 @@ impl Workspace {
         file: SourceFile,
     ) -> debian_changelog::Parse<debian_changelog::ChangeLog> {
         parse_changelog(self, file)
+    }
+
+    pub fn get_parsed_patches_series(
+        &self,
+        file: SourceFile,
+    ) -> patchkit::edit::Parse<patchkit::edit::series::lossless::SeriesFile> {
+        parse_patches_series(self, file)
     }
 
     /// Find UNRELEASED entries in the given range that can be marked for upload

--- a/vscode-debian/package.json
+++ b/vscode-debian/package.json
@@ -37,7 +37,8 @@
     "onLanguage:debsourceformat",
     "onLanguage:debsourceoptions",
     "onLanguage:debupstreammetadata",
-    "onLanguage:debrules"
+    "onLanguage:debrules",
+    "onLanguage:debpatches"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -143,6 +144,16 @@
         "filenamePatterns": [
           "**/debian/rules"
         ]
+      },
+      {
+        "id": "debpatches",
+        "aliases": [
+          "Debian Patches Series",
+          "debpatches"
+        ],
+        "filenamePatterns": [
+          "**/debian/patches/series"
+        ]
       }
     ],
     "configurationDefaults": {
@@ -177,6 +188,9 @@
         "editor.formatOnType": true
       },
       "[debrules]": {
+        "editor.colorDecorators": false
+      },
+      "[debpatches]": {
         "editor.colorDecorators": false
       }
     },
@@ -350,6 +364,13 @@
           "changelogTimestamp": ["string"],
           "changelogMetadataValue": ["string"],
           "changelogBugReference": ["markup.underline.link"]
+        }
+      },
+      {
+        "language": "debpatches",
+        "scopes": {
+          "debianValue": ["string"],
+          "debianComment": ["comment"]
         }
       }
     ]

--- a/vscode-debian/src/extension.ts
+++ b/vscode-debian/src/extension.ts
@@ -57,12 +57,13 @@ export function activate(context: ExtensionContext) {
       { scheme: 'file', language: 'debsourceoptions' },
       { scheme: 'file', language: 'debupstreammetadata' },
       { scheme: 'file', language: 'debrules' },
+      { scheme: 'file', language: 'debpatches' },
     ],
     initializationOptions: {
       upstreamOntologistNetAccess: config.get<boolean>('upstreamOntologistNetAccess', false),
     },
     synchronize: {
-      fileEvents: workspace.createFileSystemWatcher('**/debian/{control,copyright,watch,changelog,tests/control,source/format,source/options,source/local-options,upstream/metadata,rules}')
+      fileEvents: workspace.createFileSystemWatcher('**/debian/{control,copyright,watch,changelog,tests/control,source/format,source/options,source/local-options,upstream/metadata,rules,patches/series}')
     }
   };
 


### PR DESCRIPTION
close #211 
Completion for patches/series. 

Use patchkit quilt series for parsing.
Lists all patch files in debian/patches, and add completions for each of those.
Also implements strip options completions (p0,p1,p2).
Adds docs for all editors.