### PR TITLE
Add openssl-vendored feature for CI builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,7 +93,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y base-files
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} --verbose
+        run: cargo build --release --target ${{ matrix.target }} --features openssl-vendored --verbose
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           PYO3_CROSS_PYTHON_VERSION: "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test ${{ matrix.os == 'windows-latest' && '--features openssl-vendored' || '' }} --verbose
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build ${{ matrix.os == 'windows-latest' && '--features openssl-vendored' || '' }} --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,27 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
-name = "breezyshim"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903de5d500b02e67394b9f623e33aaac2d6721c26e5f94f334b987d2a8a2bf8d"
-dependencies = [
- "chrono",
- "lazy-regex",
- "lazy_static",
- "log",
- "patchkit",
- "percent-encoding",
- "pyo3",
- "pyo3-filelike",
- "regex",
- "serde",
- "tempfile",
- "url",
- "whoami",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -674,6 +653,7 @@ dependencies = [
  "launchpadlib",
  "lintian-overrides",
  "makefile-lossless",
+ "openssl",
  "patchkit",
  "rowan",
  "salsa",
@@ -695,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "debian-watch"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603aa65539430f4fdd0bb84e0b33f0664a82025c1a6e15a5e9f61c4ed64d89ad"
+checksum = "bb7b5bf6da6899c347555253e79bacb6683cfc7213db6413567bb7493f6b7b08"
 dependencies = [
  "clap",
  "deb822-lossless",
@@ -2075,6 +2055,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2071,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2409,75 +2399,6 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pyo3"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
-dependencies = [
- "chrono",
- "libc",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
- "serde",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-filelike"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8cb6cd0231ea816b4452c0cd37b5215f9ec45b66ed3e748fad8eb39cfd4997"
-dependencies = [
- "pyo3",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
-dependencies = [
- "heck",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "quinn"
@@ -2918,9 +2839,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3601,12 +3522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,14 +3970,13 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "upstream-ontologist"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8306803160cd620aa5e07136522f045fd17bcd0033cad41109ecab512d17ea"
+checksum = "620d4d2a9f8d5c90b57a83c70a3efd26eaae084be7c653bdbf041bb6c07da745"
 dependencies = [
  "async-trait",
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "breezyshim",
  "cargo_toml",
  "chrono",
  "configparser",
@@ -4082,7 +3996,6 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pulldown-cmark",
- "pyo3-filelike",
  "quote",
  "regex",
  "reqwest",
@@ -4359,7 +4272,6 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools", "text-editors"]
 [features]
 default = ["launchpad"]
 launchpad = ["dep:launchpadlib"]
+openssl-vendored = ["dep:openssl"]
 
 [dependencies]
 # debian-analyzer = "0.159.0"
@@ -30,7 +31,7 @@ deb822-fast = "0.2"
 lintian-overrides = "0.1.0"
 deb822-lossless = { version = "0.5.12" }
 yaml-edit = { version = "0.2.0" }
-upstream-ontologist = { version = "0.3", default-features = false, features = ["cargo", "debian"] }
+upstream-ontologist = { version = "0.3.17", default-features = false, features = ["cargo", "debian"] }
 futures = "0.3"
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["full"] }
@@ -42,6 +43,7 @@ salsa = ">=0.23, <0.27"
 text-size = "1.1"
 patchkit = "0.2.4"
 launchpadlib = { version = "0.5.7", optional = true, default-features = false, features = ["async", "api-v1_0", "bugs", "packages"] }
+openssl = { version = ">=0.10.64, <0.11", features = ["vendored"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
upstream-ontologist has a hard dependency on openssl. Rather than installing platform-specific OpenSSL packages on each CI runner, add an optional openssl-vendored feature that compiles OpenSSL from source. Use this in the publish workflow (all targets) and in the test workflow (Windows only).