### PR TITLE
Clear diagnostics when a file is closed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,17 @@ impl LanguageServer for Backend {
         }
     }
 
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let mut files = self.files.lock().await;
+        files.remove(&params.text_document.uri);
+        drop(files);
+        // Clear diagnostics so stale squiggles don't linger after the file
+        // is closed.
+        self.client
+            .publish_diagnostics(params.text_document.uri, vec![], None)
+            .await;
+    }
+
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
         let uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;


### PR DESCRIPTION
Without a did_close handler, squiggles produced by lintian-brush detectors lingered indefinitely after closing a file. Publishing an empty diagnostic list on close clears them.