### PR TITLE
Accept --stdio as a no-op CLI flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2089,6 +2089,11 @@ impl LanguageServer for Backend {
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
+    /// Accepted for compatibility with LSP clients that append `--stdio`
+    /// (e.g. vscode-languageclient). The server always speaks LSP over
+    /// stdio when no subcommand is given, so the flag is a no-op.
+    #[arg(long, hide = true)]
+    stdio: bool,
 }
 
 /// Subcommands for debian-lsp.


### PR DESCRIPTION
vscode-languageclient appends `--stdio` when launching a server with TransportKind.stdio, even though the server always speaks LSP over stdio in that mode. The clap parser previously rejected it and the client failed to connect.