### PR TITLE
vscode: stop registering server command IDs on the client

### DIFF
--- a/src/changelog/actions.rs
+++ b/src/changelog/actions.rs
@@ -6,18 +6,6 @@ use crate::position::Source;
 
 pub const ADD_CHANGELOG_ENTRY_COMMAND: &str = "debian-lsp.addChangelogEntry";
 
-/// Return a palette command entry for "Add new changelog entry".
-///
-/// This is intentionally a `Command` (not a `CodeAction`) so that VS Code
-/// only surfaces it via the command palette, not the automatic lightbulb.
-pub fn get_add_changelog_entry_command(uri: &Uri) -> CodeActionOrCommand {
-    CodeActionOrCommand::Command(Command {
-        title: "Add new changelog entry".to_string(),
-        command: ADD_CHANGELOG_ENTRY_COMMAND.to_string(),
-        arguments: Some(vec![serde_json::json!(uri.as_str())]),
-    })
-}
-
 /// Generate a TextEdit that updates the timestamp of the first UNRELEASED entry
 /// to the current time. Returns `None` if the first entry is not UNRELEASED or
 /// has no timestamp.

--- a/src/control/actions.rs
+++ b/src/control/actions.rs
@@ -146,18 +146,6 @@ pub fn build_add_binary_package_edit(
     })
 }
 
-/// Return a palette command entry for "Add binary package".
-///
-/// This is intentionally a `Command` (not a `CodeAction`) so that VS Code
-/// only surfaces it via the command palette, not the automatic lightbulb.
-pub fn get_add_binary_package_command(uri: &Uri) -> CodeActionOrCommand {
-    CodeActionOrCommand::Command(Command {
-        title: "Add binary package".to_string(),
-        command: ADD_BINARY_PACKAGE_COMMAND.to_string(),
-        arguments: Some(vec![serde_json::json!(uri.as_str())]),
-    })
-}
-
 /// Generate field casing fix actions for a control file
 ///
 /// # Arguments

--- a/src/main.rs
+++ b/src/main.rs
@@ -961,14 +961,6 @@ impl LanguageServer for Backend {
                     actions.push(action);
                 }
 
-                // "Add binary package" is document-level and should only
-                // appear via the command palette, not the lightbulb.
-                if params.context.trigger_kind != Some(CodeActionTriggerKind::AUTOMATIC) {
-                    actions.push(control::get_add_binary_package_command(
-                        &params.text_document.uri,
-                    ));
-                }
-
                 // Add field casing fixes. For source.fixAll, scan the whole
                 // document and ignore the diagnostics filter so a single
                 // "Fix all" can apply every casing fix at once.
@@ -1046,13 +1038,6 @@ impl LanguageServer for Backend {
                 actions.extend(casing_actions);
             }
             FileType::Changelog => {
-                // Add new changelog entry: document-level, palette only.
-                if params.context.trigger_kind != Some(CodeActionTriggerKind::AUTOMATIC) {
-                    actions.push(changelog::get_add_changelog_entry_command(
-                        &params.text_document.uri,
-                    ));
-                }
-
                 // Check for UNRELEASED entries in the requested range and offer "Mark for upload"
                 if let Some(text_range) = text_range {
                     let unreleased_entries = workspace

--- a/vscode-debian/package-lock.json
+++ b/vscode-debian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-debian",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-debian",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0+",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-debian/package.json
+++ b/vscode-debian/package.json
@@ -44,12 +44,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "debian-lsp.addBinaryPackage",
+        "command": "debian-lsp.palette.addBinaryPackage",
         "title": "Add Binary Package",
         "category": "Debian"
       },
       {
-        "command": "debian-lsp.addChangelogEntry",
+        "command": "debian-lsp.palette.addChangelogEntry",
         "title": "Add New Changelog Entry",
         "category": "Debian"
       }

--- a/vscode-debian/src/extension.ts
+++ b/vscode-debian/src/extension.ts
@@ -93,9 +93,11 @@ export function activate(context: ExtensionContext) {
     }
   }, null, context.subscriptions);
 
-  // Register command palette commands that delegate to the LSP server.
+  // Palette wrappers: supply the active document URI as the first argument
+  // to the server-side handler. The command IDs differ from the LSP-registered
+  // ones to avoid duplicate registration with vscode-languageclient.
   context.subscriptions.push(
-    commands.registerCommand('debian-lsp.addBinaryPackage', () => {
+    commands.registerCommand('debian-lsp.palette.addBinaryPackage', () => {
       const uri = window.activeTextEditor?.document.uri.toString();
       if (uri) {
         client.sendRequest('workspace/executeCommand', {
@@ -104,7 +106,7 @@ export function activate(context: ExtensionContext) {
         });
       }
     }),
-    commands.registerCommand('debian-lsp.addChangelogEntry', () => {
+    commands.registerCommand('debian-lsp.palette.addChangelogEntry', () => {
       const uri = window.activeTextEditor?.document.uri.toString();
       if (uri) {
         client.sendRequest('workspace/executeCommand', {


### PR DESCRIPTION
The server advertises `debian-lsp.addBinaryPackage` and `debian-lsp.addChangelogEntry` in `executeCommandProvider`; vscode-languageclient auto-registers a VS Code command for each entry in that list. The extension was also calling `commands.registerCommand` on the same IDs, causing VS Code to throw "command already exists" at startup.