### PR TITLE
Refresh sibling diagnostics when an override changes

### DIFF
--- a/src/lsp_integration_tests.rs
+++ b/src/lsp_integration_tests.rs
@@ -383,3 +383,170 @@ async fn test_binary_package_fix_targets_correct_paragraph() {
         edit["range"]["start"]["line"]
     );
 }
+
+/// Editing a `lintian-overrides` buffer re-publishes the diagnostics of
+/// open sibling files: a changelog issue suppressed by an override shows
+/// faded, and clearing the override un-fades it — without reopening the
+/// changelog.
+#[tokio::test]
+#[cfg(feature = "lintian-brush")]
+async fn test_overrides_change_refreshes_sibling_changelog() {
+    use tokio::time::{timeout, Duration};
+
+    let temp = tempfile::tempdir().unwrap();
+    let debian_dir = temp.path().join("debian");
+    std::fs::create_dir_all(debian_dir.join("source")).unwrap();
+
+    // 2024-03-09 is a Saturday, so "Mon, 09 Mar 2024" is a wrong
+    // day-of-week — the detector emits info "2024-03-09 is a Saturday".
+    let changelog_text = "test-pkg (1.0-1) unstable; urgency=low\n\n  * Initial release.\n\n -- Alice <alice@example.com>  Mon, 09 Mar 2024 00:00:00 +0000\n";
+    std::fs::write(debian_dir.join("changelog"), changelog_text).unwrap();
+    // The override suppresses that exact issue.
+    let overrides_path = debian_dir.join("source/lintian-overrides");
+    std::fs::write(
+        &overrides_path,
+        "debian-changelog-has-wrong-day-of-week 2024-03-09 is a Saturday\n",
+    )
+    .unwrap();
+
+    let changelog_uri = Uri::from_file_path(debian_dir.join("changelog")).unwrap();
+    let overrides_uri = Uri::from_file_path(&overrides_path).unwrap();
+
+    let (mut service, mut socket) = setup_server().await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    tokio::spawn(async move {
+        while let Some(msg) = socket.next().await {
+            let _ = tx.send(msg);
+        }
+    });
+
+    let _ = service
+        .call(
+            serde_json::from_value(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": { "capabilities": {} }
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Open the changelog. Its day-of-week issue is overridden, so the
+    // published diagnostic must be faded (UNNECESSARY tag, HINT severity).
+    let _ = service
+        .call(
+            serde_json::from_value(json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": changelog_uri.clone(),
+                        "languageId": "debchangelog",
+                        "version": 1,
+                        "text": changelog_text
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Wait for the faded day-of-week diagnostic on the changelog.
+    let day_of_week_diag = |msg_json: &serde_json::Value| -> Option<serde_json::Value> {
+        if msg_json["method"] != "textDocument/publishDiagnostics"
+            || msg_json["params"]["uri"] != serde_json::to_value(&changelog_uri).unwrap()
+        {
+            return None;
+        }
+        msg_json["params"]["diagnostics"]
+            .as_array()?
+            .iter()
+            .find(|d| d["code"].as_str() == Some("debian-changelog-has-wrong-day-of-week"))
+            .cloned()
+    };
+
+    let faded = timeout(Duration::from_secs(15), async {
+        while let Some(msg) = rx.recv().await {
+            let msg_json = serde_json::to_value(msg).unwrap();
+            if let Some(d) = day_of_week_diag(&msg_json) {
+                return Some(d);
+            }
+        }
+        None
+    })
+    .await
+    .ok()
+    .flatten()
+    .expect("expected a day-of-week diagnostic on the changelog");
+    // 1 == DiagnosticSeverity::WARNING, 4 == HINT; UNNECESSARY tag == 1.
+    assert_eq!(faded["severity"], 4, "overridden diagnostic should be HINT");
+    assert_eq!(
+        faded["tags"],
+        json!([1]),
+        "overridden diagnostic should carry the UNNECESSARY tag"
+    );
+
+    // Open the override file, then change it to remove the override.
+    let _ = service
+        .call(
+            serde_json::from_value(json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": overrides_uri.clone(),
+                        "languageId": "plaintext",
+                        "version": 1,
+                        "text": "debian-changelog-has-wrong-day-of-week 2024-03-09 is a Saturday\n"
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let _ = service
+        .call(
+            serde_json::from_value(json!({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didChange",
+                "params": {
+                    "textDocument": { "uri": overrides_uri.clone(), "version": 2 },
+                    "contentChanges": [{ "text": "" }]
+                }
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The changelog must be re-published with the issue no longer faded:
+    // a normal INFORMATION diagnostic, no UNNECESSARY tag.
+    let unfaded = timeout(Duration::from_secs(15), async {
+        while let Some(msg) = rx.recv().await {
+            let msg_json = serde_json::to_value(msg).unwrap();
+            if let Some(d) = day_of_week_diag(&msg_json) {
+                if d["tags"].is_null() {
+                    return Some(d);
+                }
+            }
+        }
+        None
+    })
+    .await
+    .ok()
+    .flatten()
+    .expect("changelog diagnostic should be re-published un-faded after the override is removed");
+    // 3 == DiagnosticSeverity::INFORMATION.
+    assert_eq!(
+        unfaded["severity"], 3,
+        "un-overridden diagnostic should be INFORMATION"
+    );
+    assert!(
+        unfaded["tags"].is_null(),
+        "un-overridden diagnostic should carry no tags"
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,6 +493,74 @@ impl Backend {
             .map(|p| p.to_path_buf())
     }
 
+    /// Re-analyse the open files in the same package as `overrides_uri`
+    /// after its lintian-overrides content changed.
+    ///
+    /// An override line suppresses (fades) a lintian-brush diagnostic in
+    /// a *different* file — `debian/changelog`, `debian/control`, ... —
+    /// so editing the override file must re-publish those siblings'
+    /// diagnostics for the faded state to track the edit. The override
+    /// file itself is skipped (its own diagnostics don't depend on it).
+    ///
+    /// Each sibling is recomputed at [`RunPhase::Open`] — the cheap
+    /// detectors (the day-of-week fader among them) cover the override
+    /// fade state. Network-cost detectors are not re-run here.
+    #[cfg(feature = "lintian-brush")]
+    async fn refresh_sibling_diagnostics(&self, overrides_uri: &Uri) {
+        let Some(debian_dir) = Self::find_debian_dir(overrides_uri) else {
+            return;
+        };
+
+        // Collect the open siblings (same `debian/` dir, not the
+        // override file itself) up front, releasing the lock before the
+        // analysis work.
+        let siblings: Vec<(Uri, FileInfo)> = {
+            let files = self.files.lock().await;
+            files
+                .iter()
+                .filter(|(uri, _)| *uri != overrides_uri)
+                .filter(|(uri, _)| Self::find_debian_dir(uri).as_deref() == Some(&debian_dir))
+                .map(|(uri, info)| (uri.clone(), *info))
+                .collect()
+        };
+        if siblings.is_empty() {
+            return;
+        }
+
+        let show_overridden = self.settings.lock().await.show_overridden_issues;
+        for (uri, info) in siblings {
+            // Lock `files` and `workspace` one at a time, never nested —
+            // other handlers take them in the opposite order, and holding
+            // both at once risks an AB-BA deadlock.
+            let open_files_snapshot = self.files.lock().await.clone();
+            let workspace = self.workspace.lock().await.clone();
+            let diagnostics = match Self::collect_diagnostics(
+                uri.clone(),
+                info.source_file,
+                info.file_type,
+                workspace,
+                open_files_snapshot,
+                RunPhase::Open,
+                None,
+                show_overridden,
+                #[cfg(feature = "multiarch-hints")]
+                Some(self.multiarch_hints_store.clone()),
+            )
+            .await
+            {
+                Ok(Some(d)) => d,
+                Ok(None) => continue,
+                Err(e) => {
+                    self.client.log_message(MessageType::ERROR, &e).await;
+                    continue;
+                }
+            };
+            self.client
+                .publish_diagnostics(uri.clone(), diagnostics, None)
+                .await;
+        }
+    }
+
     /// Get or load the changelog source file for the debian directory
     /// containing the given URI. If the changelog is already open, reuses the
     /// existing workspace entry; otherwise reads it from disk and inserts it
@@ -837,6 +905,15 @@ impl LanguageServer for Backend {
                 .await;
         }
 
+        // Opening a lintian-overrides file may change which sibling
+        // diagnostics are suppressed (its on-disk content is now an open
+        // buffer that may differ) — re-analyse the open siblings.
+        #[cfg(feature = "lintian-brush")]
+        if file_type == FileType::LintianOverrides {
+            self.refresh_sibling_diagnostics(&params.text_document.uri)
+                .await;
+        }
+
         self.send_package_status(&params.text_document.uri).await;
     }
 
@@ -942,6 +1019,15 @@ impl LanguageServer for Backend {
         if let Some(diagnostics) = diagnostics {
             self.client
                 .publish_diagnostics(params.text_document.uri.clone(), diagnostics, None)
+                .await;
+        }
+
+        // Editing a lintian-overrides file changes which sibling
+        // diagnostics are suppressed — re-analyse the open files in the
+        // same package so their faded state tracks the edit.
+        #[cfg(feature = "lintian-brush")]
+        if file_type == FileType::LintianOverrides {
+            self.refresh_sibling_diagnostics(&params.text_document.uri)
                 .await;
         }
 


### PR DESCRIPTION
Editing a lintian-overrides file changes which sibling diagnostics are suppressed, but the siblings (debian/changelog, debian/control, ...) are only re-analysed on their own did_open/did_change. So a faded diagnostic stays faded — or stays a normal squiggle — until the affected file is reopened.