### PR TITLE
Add native spell-checking for comments across packaging files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,7 +293,25 @@ impl Backend {
             multiarch_hints::hints::HintsStore,
         >,
     ) -> tower_lsp_server::jsonrpc::Result<Option<Vec<Diagnostic>>> {
-        let builtin = Self::builtin_diagnostics(&uri, source_file, file_type, &workspace);
+        #[cfg_attr(not(feature = "spellcheck"), allow(unused_mut))]
+        let mut builtin = Self::builtin_diagnostics(&uri, source_file, file_type, &workspace);
+
+        #[cfg(feature = "spellcheck")]
+        {
+            let source_text = workspace.source_text(source_file);
+            let idx = workspace.get_line_index(source_file);
+            let src = Source::new(&source_text, &idx);
+            let comment_diags: Vec<Diagnostic> =
+                Self::comment_spelling_findings(source_file, file_type, src, &workspace)
+                    .into_iter()
+                    .map(|located| {
+                        crate::spelling::make_diagnostic(located.range, &located.finding)
+                    })
+                    .collect();
+            if !comment_diags.is_empty() {
+                builtin.get_or_insert_with(Vec::new).extend(comment_diags);
+            }
+        }
 
         #[cfg(feature = "lintian-brush")]
         let lb = Self::lintian_brush_diagnostics(
@@ -423,6 +441,63 @@ impl Backend {
             | FileType::Rules
             | FileType::LintianOverrides
             | FileType::DebcargoToml => None,
+        }
+    }
+
+    /// Spell-check the comment tokens of any comment-bearing file. The generic
+    /// walker lives in [`crate::spelling::comments`]; this only selects the
+    /// right cached parse tree per file type. Returns findings located at LSP
+    /// ranges, shared by diagnostics and code actions.
+    #[cfg(feature = "spellcheck")]
+    fn comment_spelling_findings(
+        source_file: workspace::SourceFile,
+        file_type: FileType,
+        src: Source<'_>,
+        workspace: &Workspace,
+    ) -> Vec<crate::spelling::LocatedFinding> {
+        use crate::spelling::comments;
+
+        match file_type {
+            FileType::Control | FileType::TestsControl | FileType::SourceOptions => {
+                let parsed = workspace.get_parsed_deb822(source_file);
+                comments::deb822_comment_findings(&parsed.tree(), src)
+            }
+            FileType::Copyright => {
+                let parsed = workspace.get_parsed_copyright(source_file);
+                comments::deb822_comment_findings(parsed.tree().as_deb822(), src)
+            }
+            FileType::Patch => {
+                let (parsed, _) = workspace.get_parsed_dep3_header(source_file);
+                comments::deb822_comment_findings(&parsed.tree(), src)
+            }
+            FileType::Watch => {
+                let parsed = workspace.get_parsed_watch(source_file);
+                comments::watch_comment_findings(&parsed, src)
+            }
+            FileType::Changelog => {
+                let parsed = workspace.get_parsed_changelog(source_file);
+                comments::changelog_comment_findings(&parsed, src)
+            }
+            FileType::Rules => {
+                let parsed = workspace.get_parsed_rules(source_file);
+                comments::rules_comment_findings(&parsed.tree(), src)
+            }
+            FileType::LintianOverrides => {
+                let parsed = workspace.get_parsed_lintian_overrides(source_file);
+                comments::lintian_overrides_comment_findings(&parsed.tree(), src)
+            }
+            FileType::PatchesSeries => {
+                let parsed = workspace.get_parsed_patches_series(source_file);
+                comments::patches_series_comment_findings(&parsed.tree(), src)
+            }
+            // SourceFormat has no comments; DebcargoToml is parsed line-by-line
+            // with no lossless tree; UpstreamMetadata's yaml-edit parser does
+            // not expose its comment tokens publicly.
+            // TODO: spell-check UpstreamMetadata comments once yaml-edit exposes
+            // a way to iterate comment trivia.
+            FileType::SourceFormat | FileType::UpstreamMetadata | FileType::DebcargoToml => {
+                Vec::new()
+            }
         }
     }
 
@@ -1347,7 +1422,11 @@ impl LanguageServer for Backend {
             | FileType::Watch
             | FileType::UpstreamMetadata
             | FileType::TestsControl
-            | FileType::Patch => {}
+            | FileType::Patch
+            | FileType::Rules
+            | FileType::SourceOptions
+            | FileType::LintianOverrides
+            | FileType::PatchesSeries => {}
             _ => return Ok(None),
         }
 
@@ -1356,6 +1435,24 @@ impl LanguageServer for Backend {
         let src = Source::new(&source_text, &idx);
 
         let mut actions = Vec::new();
+
+        // Quick-fix actions for misspelled words in comments. Collected up
+        // front so they are offered for every comment-bearing format, including
+        // those (rules, series, lintian-overrides) that have no other actions.
+        #[cfg(feature = "spellcheck")]
+        {
+            let findings = Self::comment_spelling_findings(
+                file_info.source_file,
+                file_info.file_type,
+                src,
+                &workspace,
+            );
+            actions.extend(crate::spelling::make_actions(
+                &params.text_document.uri,
+                findings,
+                &params.context.diagnostics,
+            ));
+        }
 
         let text_range = src.try_lsp_range_to_text_range(&params.range);
 
@@ -1369,10 +1466,14 @@ impl LanguageServer for Backend {
             })
             .unwrap_or(false);
 
-        match file_info.file_type {
+        // A labelled block so the per-format arms can bail out (e.g. on an
+        // unmappable range) without discarding the comment-spelling actions
+        // already collected above.
+        'format_actions: {
+            match file_info.file_type {
             FileType::Control => {
                 let Some(text_range) = text_range else {
-                    return Ok(None);
+                    break 'format_actions;
                 };
 
                 // Add wrap-and-sort action
@@ -1425,7 +1526,7 @@ impl LanguageServer for Backend {
             }
             FileType::Copyright => {
                 let Some(text_range) = text_range else {
-                    return Ok(None);
+                    break 'format_actions;
                 };
 
                 // Add wrap-and-sort action
@@ -1535,9 +1636,18 @@ impl LanguageServer for Backend {
                     ));
                 }
             }
-            FileType::Watch | FileType::UpstreamMetadata | FileType::TestsControl => {}
+            FileType::Watch
+            | FileType::UpstreamMetadata
+            | FileType::TestsControl
+            // These formats contribute only comment-spelling actions, which are
+            // collected before this match.
+            | FileType::Rules
+            | FileType::SourceOptions
+            | FileType::LintianOverrides
+            | FileType::PatchesSeries => {}
             _ => unreachable!(),
         }
+        } // 'format_actions
 
         #[cfg(any(feature = "lintian-brush", feature = "multiarch-hints"))]
         let open_files_snapshot = files.clone();

--- a/src/spelling/comments.rs
+++ b/src/spelling/comments.rs
@@ -1,0 +1,241 @@
+//! Spell-checking for comment tokens in any rowan-based packaging file.
+//!
+//! Nearly every format the LSP understands exposes its comments as a single
+//! token kind in a lossless syntax tree. This module walks such a tree, runs
+//! the generic [`check_text`](super::check_text) over each comment token, and
+//! maps the findings back to source ranges. A comment token's `text_range()`
+//! is already in source coordinates, so a typo's byte offset within the token
+//! text adds directly onto the token start; no continuation-line joining is
+//! involved, unlike [`crate::control::spelling`].
+//!
+//! Callers supply a predicate over the format's own `SyntaxKind` to identify
+//! comment tokens, keeping this module independent of any one parser crate.
+
+use rowan::{Language, SyntaxNode, TextRange, TextSize};
+
+use super::LocatedFinding;
+use crate::position::Source;
+
+/// Find spelling mistakes in every comment token of a syntax tree.
+///
+/// `is_comment` decides which token kinds hold comment prose; only those are
+/// checked. Findings are mapped to LSP ranges via `src`.
+pub fn comment_findings<L: Language>(
+    root: &SyntaxNode<L>,
+    src: Source<'_>,
+    is_comment: impl Fn(L::Kind) -> bool,
+) -> Vec<LocatedFinding> {
+    let mut findings = Vec::new();
+
+    for element in root.descendants_with_tokens() {
+        let Some(token) = element.into_token() else {
+            continue;
+        };
+        if !is_comment(token.kind()) {
+            continue;
+        }
+
+        let token_start = token.text_range().start();
+        for finding in super::check_text(token.text()) {
+            let span = finding.span();
+            let start = token_start + TextSize::new(span.start as u32);
+            let end = token_start + TextSize::new(span.end as u32);
+            let range = src.text_range_to_lsp_range(TextRange::new(start, end));
+            findings.push(LocatedFinding { range, finding });
+        }
+    }
+
+    findings
+}
+
+/// Comment findings for a deb822-based file (control, copyright, dep3 headers,
+/// tests/control, source/options).
+pub fn deb822_comment_findings(
+    deb822: &deb822_lossless::Deb822,
+    src: Source<'_>,
+) -> Vec<LocatedFinding> {
+    use deb822_lossless::SyntaxKind;
+    use rowan::ast::AstNode;
+    comment_findings(deb822.syntax(), src, |k| k == SyntaxKind::COMMENT)
+}
+
+/// Comment findings for a `debian/rules` makefile.
+pub fn rules_comment_findings(
+    makefile: &makefile_lossless::Makefile,
+    src: Source<'_>,
+) -> Vec<LocatedFinding> {
+    use makefile_lossless::SyntaxKind;
+    use rowan::ast::AstNode;
+    comment_findings(makefile.syntax(), src, |k| k == SyntaxKind::COMMENT)
+}
+
+/// Comment findings for a `debian/changelog`.
+pub fn changelog_comment_findings(
+    parse: &debian_changelog::Parse<debian_changelog::ChangeLog>,
+    src: Source<'_>,
+) -> Vec<LocatedFinding> {
+    use debian_changelog::SyntaxKind;
+    // `syntax_node()` yields tokens even when the changelog has parse errors.
+    comment_findings(&parse.syntax_node(), src, |k| k == SyntaxKind::COMMENT)
+}
+
+/// Comment findings for a `debian/<pkg>.lintian-overrides`.
+pub fn lintian_overrides_comment_findings(
+    overrides: &lintian_overrides::LintianOverrides,
+    src: Source<'_>,
+) -> Vec<LocatedFinding> {
+    use lintian_overrides::{AstNode as _, SyntaxKind};
+    comment_findings(overrides.syntax(), src, |k| k == SyntaxKind::COMMENT)
+}
+
+/// Comment findings for a `debian/patches/series` file. The comment text after
+/// a `#` is a `TEXT` token; the `#` itself (`HASH`) carries no prose.
+pub fn patches_series_comment_findings(
+    series: &patchkit::edit::series::lossless::SeriesFile,
+    src: Source<'_>,
+) -> Vec<LocatedFinding> {
+    use patchkit::edit::series::lex::SyntaxKind;
+    use rowan::ast::AstNode;
+    comment_findings(series.syntax(), src, |k| k == SyntaxKind::TEXT)
+}
+
+/// Comment findings for a `debian/watch` file, covering both the deb822 (v5)
+/// and line-based (v1-4) representations. The cached parse is reused as-is.
+pub fn watch_comment_findings(
+    parse: &debian_watch::parse::Parse,
+    src: Source<'_>,
+) -> Vec<LocatedFinding> {
+    match parse.to_watch_file() {
+        debian_watch::parse::ParsedWatchFile::Deb822(wf) => {
+            deb822_comment_findings(wf.as_deb822(), src)
+        }
+        debian_watch::parse::ParsedWatchFile::LineBased(wf) => {
+            use debian_watch::SyntaxKind;
+            comment_findings(wf.syntax(), src, |k| k == SyntaxKind::COMMENT)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::Workspace;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    /// Build a workspace with one file and return its bits for the per-format
+    /// finder. The parse trees pulled below are the salsa-cached ASTs, the
+    /// same ones the LSP serves diagnostics from.
+    fn setup(path: &str, content: &str) -> (Workspace, crate::workspace::SourceFile) {
+        let mut workspace = Workspace::new();
+        let url = str::parse(path).unwrap();
+        let file = workspace.update_file(url, content.to_string());
+        (workspace, file)
+    }
+
+    fn assert_single(found: &[LocatedFinding], typo: &str, correction: &str, range: Range) {
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].finding.typo, typo);
+        assert_eq!(found[0].finding.corrections, vec![correction.to_string()]);
+        assert_eq!(found[0].range, range);
+    }
+
+    #[test]
+    fn test_rules_comment() {
+        let content = "# This is a libary comment\nbuild:\n\techo hi\n";
+        let (ws, file) = setup("file:///debian/rules", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        let found = rules_comment_findings(&ws.get_parsed_rules(file).tree(), src);
+        // "libary" starts at column 12 of line 0.
+        assert_single(
+            &found,
+            "libary",
+            "library",
+            Range::new(Position::new(0, 12), Position::new(0, 18)),
+        );
+    }
+
+    #[test]
+    fn test_rules_ignores_non_comment_tokens() {
+        // A typo-shaped target name must not be flagged: it is not a comment.
+        let content = "libary:\n\techo hi\n";
+        let (ws, file) = setup("file:///debian/rules", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        assert!(rules_comment_findings(&ws.get_parsed_rules(file).tree(), src).is_empty());
+    }
+
+    #[test]
+    fn test_deb822_comment() {
+        let content = "# a libary comment\nSource: foo\n";
+        let (ws, file) = setup("file:///debian/control", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        let found = deb822_comment_findings(&ws.get_parsed_deb822(file).tree(), src);
+        assert_single(
+            &found,
+            "libary",
+            "library",
+            Range::new(Position::new(0, 4), Position::new(0, 10)),
+        );
+    }
+
+    #[test]
+    fn test_lintian_overrides_comment() {
+        let content = "# overide this tag\nfoo: some-tag\n";
+        let (ws, file) = setup("file:///debian/source/lintian-overrides", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        let found =
+            lintian_overrides_comment_findings(&ws.get_parsed_lintian_overrides(file).tree(), src);
+        assert_single(
+            &found,
+            "overide",
+            "override",
+            Range::new(Position::new(0, 2), Position::new(0, 9)),
+        );
+    }
+
+    #[test]
+    fn test_patches_series_comment() {
+        let content = "# a libary patch\nfoo.patch\n";
+        let (ws, file) = setup("file:///debian/patches/series", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        let found =
+            patches_series_comment_findings(&ws.get_parsed_patches_series(file).tree(), src);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].finding.typo, "libary");
+    }
+
+    #[test]
+    fn test_changelog_comment() {
+        // A changelog comment is a '#' line at column 0 (an indented '#' is
+        // ordinary entry body, not a comment).
+        let content = "# a libary note\nfoo (1.0-1) unstable; urgency=low\n\n  * Initial release.\n\n -- Foo <foo@example.com>  Mon, 01 Jan 2024 00:00:00 +0000\n";
+        let (ws, file) = setup("file:///debian/changelog", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        let found = changelog_comment_findings(&ws.get_parsed_changelog(file), src);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].finding.typo, "libary");
+    }
+
+    #[test]
+    fn test_watch_linebased_comment() {
+        let content = "# a libary comment\nversion=4\nhttps://example.com/foo-(.+).tar.gz\n";
+        let (ws, file) = setup("file:///debian/watch", content);
+        let text = ws.source_text(file);
+        let idx = ws.get_line_index(file);
+        let src = Source::new(&text, &idx);
+        let found = watch_comment_findings(&ws.get_parsed_watch(file), src);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].finding.typo, "libary");
+    }
+}

--- a/src/spelling/mod.rs
+++ b/src/spelling/mod.rs
@@ -14,6 +14,7 @@
 
 mod dict;
 
+pub mod comments;
 pub mod deb822;
 
 use tower_lsp_server::ls_types::{


### PR DESCRIPTION
UpstreamMetadata is left out for now: yaml-edit does not expose its comment trivia publicly.