### PR TITLE
changelog: Link file and bug mentions in changelog entries

### DIFF
--- a/src/changelog/document_link.rs
+++ b/src/changelog/document_link.rs
@@ -1,0 +1,233 @@
+//! Document link support for debian/changelog files.
+//!
+//! Turns mentions in changelog detail lines into clickable links:
+//!
+//! - packaging files (e.g. `d/control`, `debian/patches/03_fix.patch`) jump
+//!   to the referenced file when it exists on disk;
+//! - bug references (`Closes: #NNN`, `LP: #NNN`) open the bug on its tracker.
+
+use debian_changelog::bugs::iter_bug_refs;
+use debian_changelog::SyntaxKind;
+use rowan::ast::AstNode;
+use tower_lsp_server::ls_types::{DocumentLink, Range, Uri};
+
+use crate::changelog::file_refs::{iter_file_refs, iter_patch_word_refs};
+use crate::position::Source;
+
+/// Get document links for file and bug mentions in a changelog file.
+///
+/// `uri` is the changelog's URI; file paths are resolved relative to the
+/// source-tree root (the parent of `debian/`). File mentions only produce a
+/// link when they resolve to an existing file; bug references always link to
+/// their tracker's web page.
+pub fn get_document_links(
+    parse: &debian_changelog::Parse<debian_changelog::ChangeLog>,
+    src: Source<'_>,
+    uri: &Uri,
+) -> Vec<DocumentLink> {
+    let Some(changelog) = debian_changelog::ChangeLog::cast(parse.syntax_node()) else {
+        return Vec::new();
+    };
+    let root = source_root(uri);
+
+    let mut links = Vec::new();
+    for token in changelog
+        .syntax()
+        .descendants_with_tokens()
+        .filter_map(|e| e.into_token())
+    {
+        if token.kind() != SyntaxKind::DETAIL {
+            continue;
+        }
+        let detail_start: usize = token.text_range().start().into();
+        let detail_text = token.text();
+
+        // File mentions resolve against the source tree on disk. Explicit
+        // `d/...` paths and the prose `patch <name>` form are both gated on
+        // the target existing, which also disambiguates the loose patch-word
+        // heuristic.
+        if let Some(root) = root.as_deref() {
+            let mentions = iter_file_refs(detail_text)
+                .into_iter()
+                .chain(iter_patch_word_refs(detail_text));
+            for file_ref in mentions {
+                let target_path = root.join(&file_ref.path);
+                if !target_path.is_file() {
+                    continue;
+                }
+                let Some(target) = Uri::from_file_path(&target_path) else {
+                    continue;
+                };
+                links.push(DocumentLink {
+                    range: span_range(src, detail_start, file_ref.start, file_ref.end),
+                    target: Some(target),
+                    tooltip: Some(file_ref.path),
+                    data: None,
+                });
+            }
+        }
+
+        // Bug references link to the tracker's web page.
+        for bug_ref in iter_bug_refs(detail_text) {
+            let Ok(target) = bug_ref.bug.url().parse::<Uri>() else {
+                continue;
+            };
+            links.push(DocumentLink {
+                range: span_range(src, detail_start, bug_ref.start, bug_ref.end),
+                target: Some(target),
+                tooltip: None,
+                data: None,
+            });
+        }
+    }
+
+    links
+}
+
+/// Build an LSP range for a `[rel_start, rel_end)` span within a detail token
+/// that begins at byte `detail_start` in the document.
+fn span_range(src: Source<'_>, detail_start: usize, rel_start: usize, rel_end: usize) -> Range {
+    let start = (detail_start + rel_start) as u32;
+    let end = (detail_start + rel_end) as u32;
+    src.text_range_to_lsp_range(text_size::TextRange::new(start.into(), end.into()))
+}
+
+/// Resolve the source-tree root (the directory containing `debian/`) from a
+/// changelog URI of the form `.../debian/changelog`.
+fn source_root(uri: &Uri) -> Option<std::path::PathBuf> {
+    let path = uri.to_file_path()?;
+    // `<root>/debian/changelog` -> `<root>`.
+    Some(path.parent()?.parent()?.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::position::LineIndex;
+
+    fn parse(text: &str) -> debian_changelog::Parse<debian_changelog::ChangeLog> {
+        debian_changelog::ChangeLog::parse(text)
+    }
+
+    fn write_tree(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for (rel, content) in files {
+            let path = dir.path().join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, content).unwrap();
+        }
+        dir
+    }
+
+    const CL: &str = "\
+hello (2.10-3) unstable; urgency=medium
+
+  * d/control: Add python3-merge3 as Build Dependency.
+  * d/patches/03_fix.patch: Remove patch.
+  * d/missing.conf: nothing here.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 27 May 2026 12:00:00 +0000
+";
+
+    #[test]
+    fn links_existing_files_only() {
+        let dir = write_tree(&[
+            ("debian/changelog", CL),
+            ("debian/control", "Source: hello\n"),
+            ("debian/patches/03_fix.patch", "--- a/x\n+++ b/x\n"),
+        ]);
+        let cl_path = dir.path().join("debian/changelog");
+        let uri = Uri::from_file_path(&cl_path).unwrap();
+        let idx = LineIndex::new(CL);
+        let src = Source::new(CL, &idx);
+
+        let links = get_document_links(&parse(CL), src, &uri);
+        let tooltips: Vec<_> = links.iter().map(|l| l.tooltip.clone().unwrap()).collect();
+        assert_eq!(
+            tooltips,
+            vec!["debian/control", "debian/patches/03_fix.patch"]
+        );
+
+        // The control link targets the real file.
+        let control_uri = Uri::from_file_path(dir.path().join("debian/control")).unwrap();
+        assert_eq!(links[0].target.as_ref().unwrap(), &control_uri);
+    }
+
+    #[test]
+    fn links_patch_word_when_patch_exists() {
+        let text = "\
+hello (2.10-3) unstable; urgency=medium
+
+  * Drop obsolete patch relax-pyo3.patch.
+  * Add patch nonexistent.patch.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 27 May 2026 12:00:00 +0000
+";
+        let dir = write_tree(&[
+            ("debian/changelog", text),
+            ("debian/patches/relax-pyo3.patch", "--- a/x\n+++ b/x\n"),
+        ]);
+        let uri = Uri::from_file_path(dir.path().join("debian/changelog")).unwrap();
+        let idx = LineIndex::new(text);
+        let src = Source::new(text, &idx);
+
+        let links = get_document_links(&parse(text), src, &uri);
+        // Only the existing patch links; `nonexistent.patch` is filtered out.
+        let tooltips: Vec<_> = links.iter().map(|l| l.tooltip.clone().unwrap()).collect();
+        assert_eq!(tooltips, vec!["debian/patches/relax-pyo3.patch"]);
+
+        // The link covers just the patch name, not the word "patch".
+        let start = src.try_position_to_offset(links[0].range.start).unwrap();
+        let end = src.try_position_to_offset(links[0].range.end).unwrap();
+        assert_eq!(
+            &text[usize::from(start)..usize::from(end)],
+            "relax-pyo3.patch"
+        );
+    }
+
+    #[test]
+    fn no_file_links_without_file_uri() {
+        // A non-file URI yields no file links rather than erroring; CL has no
+        // bug references either, so the result is empty.
+        let uri: Uri = "untitled:Untitled-1".parse().unwrap();
+        let idx = LineIndex::new(CL);
+        let src = Source::new(CL, &idx);
+        let links = get_document_links(&parse(CL), src, &uri);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn links_bug_references() {
+        let text = "\
+hello (2.10-3) unstable; urgency=medium
+
+  * Fix segfault. (Closes: #999888)
+  * Sync with upstream. (LP: #1234567)
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 27 May 2026 12:00:00 +0000
+";
+        // A non-file URI still yields bug links.
+        let uri: Uri = "untitled:Untitled-1".parse().unwrap();
+        let idx = LineIndex::new(text);
+        let src = Source::new(text, &idx);
+        let links = get_document_links(&parse(text), src, &uri);
+
+        let targets: Vec<_> = links
+            .iter()
+            .map(|l| l.target.as_ref().unwrap().as_str().to_owned())
+            .collect();
+        assert_eq!(
+            targets,
+            vec![
+                "https://bugs.debian.org/999888",
+                "https://bugs.launchpad.net/bugs/1234567",
+            ]
+        );
+
+        // The link covers just the digits.
+        let bug_link = &links[0];
+        let start = src.try_position_to_offset(bug_link.range.start).unwrap();
+        let end = src.try_position_to_offset(bug_link.range.end).unwrap();
+        assert_eq!(&text[usize::from(start)..usize::from(end)], "999888");
+    }
+}

--- a/src/changelog/file_refs.rs
+++ b/src/changelog/file_refs.rs
@@ -1,0 +1,332 @@
+//! Detect mentions of `debian/` files in changelog detail lines.
+//!
+//! Changelog entries routinely refer to other packaging files, e.g.
+//! `d/control`, `debian/gbp.conf` or `d/patches/03_fix.patch`. This module
+//! locates those mentions so they can be turned into clickable links (LSP
+//! document links) or cross-references (SCIP occurrences).
+//!
+//! Two forms are recognised:
+//!
+//! - explicit paths (`iter_file_refs`): `d/...` or `debian/...`;
+//! - the prose form `patch <name>` (`iter_patch_word_refs`), which names a
+//!   patch in `debian/patches/` without the directory prefix. This form is
+//!   only meaningful when the named patch actually exists, so callers should
+//!   validate the resulting path before linking.
+
+/// A file mention found in a changelog detail line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRef {
+    /// Byte offset of the mention within the searched text.
+    pub start: usize,
+    /// Byte offset one past the end of the mention.
+    pub end: usize,
+    /// The path relative to the source-tree root, always starting with
+    /// `debian/` (a leading `d/` is normalised to `debian/`).
+    pub path: String,
+}
+
+/// Characters that may appear in a path component after the `debian/` prefix.
+///
+/// Debian file and directory names are conservative; this set covers the
+/// realistic cases (alphanumerics, `.`, `_`, `-`, `+`, `/`) without dragging
+/// in surrounding punctuation like the trailing dot in "d/tests/control.".
+fn is_path_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '+' | '/')
+}
+
+/// Iterate file mentions within `text`.
+///
+/// Recognises substrings beginning with `d/` or `debian/` that are not part
+/// of a larger word (the preceding character, if any, must not be a path
+/// character). Trailing path-separator and dot characters are trimmed so a
+/// sentence-ending `d/control.` yields `debian/control`.
+pub fn iter_file_refs(text: &str) -> Vec<FileRef> {
+    let bytes = text.as_bytes();
+    let mut refs = Vec::new();
+    let mut search_from = 0;
+
+    while search_from < text.len() {
+        let Some((prefix_off, prefix_len)) = find_prefix(&text[search_from..]) else {
+            break;
+        };
+        let start = search_from + prefix_off;
+
+        // Reject when glued to a preceding path character, so we don't match
+        // the `d/` inside e.g. `upstream-d/foo` or a URL like `http://...d/x`.
+        if start > 0 {
+            let prev = text[..start].chars().next_back().unwrap();
+            if is_path_char(prev) {
+                search_from = start + prefix_len;
+                continue;
+            }
+        }
+
+        // Consume the path body following the prefix.
+        let mut end = start + prefix_len;
+        while end < bytes.len() && is_path_char(text[end..].chars().next().unwrap()) {
+            end += text[end..].chars().next().unwrap().len_utf8();
+        }
+        // Trim trailing separators and dots (sentence punctuation, stray slash).
+        while end > start + prefix_len && matches!(bytes[end - 1], b'.' | b'/') {
+            end -= 1;
+        }
+
+        let raw = &text[start..end];
+        // Require at least one component after the prefix; bare `d/` or
+        // `debian/` is not a file mention.
+        if let Some(path) = normalise(raw) {
+            refs.push(FileRef { start, end, path });
+        }
+        search_from = end.max(start + prefix_len);
+    }
+
+    refs
+}
+
+/// Iterate `patch <name>` candidates within `text`.
+///
+/// Matches the word `patch` (case-insensitive, not part of a larger word and
+/// not the plural `patches`) followed by a single whitespace-delimited token,
+/// yielding a [`FileRef`] whose `path` is `debian/patches/<token>` and whose
+/// span covers just the token. Trailing sentence punctuation on the token is
+/// trimmed.
+///
+/// This is a loose heuristic (`patch to fix the build` would match `to`), so
+/// callers must check that the path exists before turning it into a link.
+pub fn iter_patch_word_refs(text: &str) -> Vec<FileRef> {
+    let bytes = text.as_bytes();
+    let mut refs = Vec::new();
+    let mut search_from = 0;
+
+    while let Some(rel) = find_patch_word(&text[search_from..]) {
+        let word_start = search_from + rel;
+        let after = word_start + "patch".len();
+        search_from = after;
+
+        // Require whitespace separating the word from the name.
+        let mut cursor = after;
+        let ws = text[cursor..]
+            .chars()
+            .take_while(|c| c.is_whitespace())
+            .map(char::len_utf8)
+            .sum::<usize>();
+        if ws == 0 {
+            continue;
+        }
+        cursor += ws;
+
+        // Consume the name token.
+        let name_start = cursor;
+        while cursor < bytes.len() && is_path_char(text[cursor..].chars().next().unwrap()) {
+            cursor += text[cursor..].chars().next().unwrap().len_utf8();
+        }
+        let mut name_end = cursor;
+        while name_end > name_start && matches!(bytes[name_end - 1], b'.' | b'/') {
+            name_end -= 1;
+        }
+        if name_end == name_start {
+            continue;
+        }
+        let name = &text[name_start..name_end];
+        // A name containing a slash is already a path, not a bare patch name.
+        if name.contains('/') {
+            continue;
+        }
+        refs.push(FileRef {
+            start: name_start,
+            end: name_end,
+            path: format!("debian/patches/{name}"),
+        });
+    }
+
+    refs
+}
+
+/// Find the next standalone, lowercase-or-mixed-case `patch` word (not the
+/// plural `patches`) in `text`, returning its byte offset.
+fn find_patch_word(text: &str) -> Option<usize> {
+    let lower = text.to_ascii_lowercase();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find("patch") {
+        let idx = from + rel;
+        from = idx + "patch".len();
+        // Reject when glued to a preceding word or path character, so the
+        // `patch` in `prepatch` or the filename `foo.patch` isn't taken for
+        // the prose word.
+        let prev_ok = idx == 0 || !is_path_char(text[..idx].chars().next_back().unwrap());
+        // Reject the plural `patches` and any other trailing letter/digit.
+        let next_ok = !matches!(text.as_bytes().get(idx + "patch".len()), Some(b) if b.is_ascii_alphanumeric());
+        if prev_ok && next_ok {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+/// Find the next `d/` or `debian/` prefix in `text`, returning its byte offset
+/// and length. Prefers the longer `debian/` form when both start at the same
+/// position.
+fn find_prefix(text: &str) -> Option<(usize, usize)> {
+    let debian = text.find("debian/");
+    let short = text.find("d/");
+    match (debian, short) {
+        (Some(d), Some(s)) if d <= s => Some((d, "debian/".len())),
+        (Some(_), Some(s)) => Some((s, "d/".len())),
+        (Some(d), None) => Some((d, "debian/".len())),
+        (None, Some(s)) => Some((s, "d/".len())),
+        (None, None) => None,
+    }
+}
+
+/// Normalise a raw `d/...` or `debian/...` mention to a `debian/`-rooted path.
+///
+/// Returns `None` if there is no component after the prefix.
+fn normalise(raw: &str) -> Option<String> {
+    let rest = raw
+        .strip_prefix("debian/")
+        .or_else(|| raw.strip_prefix("d/"))?;
+    if rest.is_empty() {
+        return None;
+    }
+    Some(format!("debian/{rest}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(text: &str) -> Vec<String> {
+        iter_file_refs(text).into_iter().map(|r| r.path).collect()
+    }
+
+    #[test]
+    fn detects_short_form() {
+        assert_eq!(paths("d/control: Add foo"), vec!["debian/control"]);
+    }
+
+    #[test]
+    fn detects_long_form() {
+        assert_eq!(
+            paths("debian/tests/control: Add foo"),
+            vec!["debian/tests/control"]
+        );
+    }
+
+    #[test]
+    fn detects_patch_path() {
+        assert_eq!(
+            paths("d/patches/03_fix_protocol_v2_deepen_flush.patch: Remove patch."),
+            vec!["debian/patches/03_fix_protocol_v2_deepen_flush.patch"]
+        );
+    }
+
+    #[test]
+    fn trims_trailing_dot() {
+        assert_eq!(paths("d/tests/control. Add"), vec!["debian/tests/control"]);
+    }
+
+    #[test]
+    fn detects_gbp_conf() {
+        assert_eq!(
+            paths("d/gbp.conf: Update debian-branch"),
+            vec!["debian/gbp.conf"]
+        );
+    }
+
+    #[test]
+    fn span_covers_only_the_path() {
+        let refs = iter_file_refs("Update d/control now");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(
+            &"Update d/control now"[refs[0].start..refs[0].end],
+            "d/control"
+        );
+    }
+
+    #[test]
+    fn ignores_bare_prefix() {
+        assert!(paths("nothing in d/ here").is_empty());
+        assert!(paths("debian/ alone").is_empty());
+    }
+
+    #[test]
+    fn ignores_glued_prefix() {
+        // The `d/` here is part of a larger token, not a standalone mention.
+        assert!(paths("see upstreamd/control").is_empty());
+    }
+
+    #[test]
+    fn multiple_mentions() {
+        assert_eq!(
+            paths("d/control and d/rules updated"),
+            vec!["debian/control", "debian/rules"]
+        );
+    }
+
+    #[test]
+    fn patches_subdir_without_extension() {
+        assert_eq!(
+            paths("d/patches/older-pyo3: No need"),
+            vec!["debian/patches/older-pyo3"]
+        );
+    }
+
+    fn patch_words(text: &str) -> Vec<String> {
+        iter_patch_word_refs(text)
+            .into_iter()
+            .map(|r| r.path)
+            .collect()
+    }
+
+    #[test]
+    fn patch_word_with_extension() {
+        assert_eq!(
+            patch_words("Drop obsolete patch relax-pyo3.patch."),
+            vec!["debian/patches/relax-pyo3.patch"]
+        );
+    }
+
+    #[test]
+    fn patch_word_extensionless_candidate() {
+        // The heuristic accepts any token; existence is checked by the caller.
+        assert_eq!(
+            patch_words("Remove patch 03_fix"),
+            vec!["debian/patches/03_fix"]
+        );
+    }
+
+    #[test]
+    fn patch_word_case_insensitive() {
+        assert_eq!(
+            patch_words("Patch foo.patch refreshed"),
+            vec!["debian/patches/foo.patch"]
+        );
+    }
+
+    #[test]
+    fn patch_word_span_covers_name_only() {
+        let refs = iter_patch_word_refs("Drop patch relax.patch.");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(
+            &"Drop patch relax.patch."[refs[0].start..refs[0].end],
+            "relax.patch"
+        );
+    }
+
+    #[test]
+    fn patch_word_ignores_plural() {
+        assert!(patch_words("Refresh patches for the new release").is_empty());
+    }
+
+    #[test]
+    fn patch_word_ignores_glued() {
+        assert!(patch_words("a prepatch step").is_empty());
+    }
+
+    #[test]
+    fn patch_word_skips_path_token() {
+        // A token that's already a path is handled by `iter_file_refs`, so the
+        // bare-name heuristic ignores it to avoid a duplicate.
+        assert!(patch_words("see patch d/patches/foo.patch").is_empty());
+    }
+}

--- a/src/changelog/mod.rs
+++ b/src/changelog/mod.rs
@@ -1,7 +1,9 @@
 pub mod actions;
 pub mod completion;
 pub mod detection;
+pub mod document_link;
 pub mod fields;
+pub mod file_refs;
 pub mod folding;
 pub mod hover;
 pub mod inlay_hints;
@@ -15,6 +17,7 @@ pub mod symbols;
 pub use actions::*;
 pub use completion::*;
 pub use detection::is_changelog_file;
+pub use document_link::get_document_links;
 pub use folding::generate_folding_ranges;
 pub use hover::get_hover;
 pub use inlay_hints::generate_inlay_hints;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2630,6 +2630,14 @@ impl LanguageServer for Backend {
                     src,
                 )))
             }
+            FileType::Changelog => {
+                let workspace = self.workspace_clone().await;
+                let source_text = workspace.source_text(file.source_file);
+                let idx = workspace.get_line_index(file.source_file);
+                let src = Source::new(&source_text, &idx);
+                let parsed = workspace.get_parsed_changelog(file.source_file);
+                Ok(Some(changelog::get_document_links(&parsed, src, uri)))
+            }
             _ => Ok(None),
         }
     }

--- a/src/scip/changelog.rs
+++ b/src/scip/changelog.rs
@@ -7,6 +7,7 @@ use debian_changelog::{ChangeLog, SyntaxKind};
 use rowan::ast::AstNode;
 use scip::types::{Document, Occurrence, SymbolInformation, SymbolRole, SyntaxKind as ScipSyntax};
 use std::collections::BTreeSet;
+use std::path::Path;
 
 /// Indexed result for `debian/changelog`.
 pub struct ChangelogIndex {
@@ -25,7 +26,11 @@ pub struct ChangelogIndex {
 }
 
 /// Parse and index a `debian/changelog` file.
-pub fn index(text: &str, relative_path: &str) -> ChangelogIndex {
+///
+/// `root`, when given, is the source-tree root used to confirm that a prose
+/// `patch <name>` mention names an existing patch in `debian/patches/` before
+/// it is linked.
+pub fn index(text: &str, relative_path: &str, root: Option<&Path>) -> ChangelogIndex {
     let cl = ChangeLog::parse_relaxed(text);
     let lines = LineTable::new(text);
     let mut occurrences: Vec<Occurrence> = Vec::new();
@@ -38,6 +43,9 @@ pub fn index(text: &str, relative_path: &str) -> ChangelogIndex {
     let mut bug_numbers: BTreeSet<u32> = BTreeSet::new();
     let mut launchpad_bug_numbers: BTreeSet<u32> = BTreeSet::new();
     let mut cves: BTreeSet<String> = BTreeSet::new();
+    // (start, end, path) for each `debian/` file mentioned in a detail line.
+    // Emitted as references after the source name and version are known.
+    let mut file_mentions: Vec<(u32, u32, String)> = Vec::new();
 
     for (i, entry) in cl.iter().enumerate() {
         let pkg = entry.package();
@@ -129,6 +137,40 @@ pub fn index(text: &str, relative_path: &str) -> ChangelogIndex {
                 });
                 cves.insert(c.id);
             }
+
+            // Mentions of other packaging files (`d/control`, `d/patches/...`).
+            for file_ref in crate::changelog::file_refs::iter_file_refs(detail_text) {
+                let abs_start = detail_start + file_ref.start as u32;
+                let abs_end = detail_start + file_ref.end as u32;
+                file_mentions.push((abs_start, abs_end, file_ref.path));
+            }
+
+            // Prose `patch <name>` mentions, only when the named patch exists.
+            if let Some(root) = root {
+                for file_ref in crate::changelog::file_refs::iter_patch_word_refs(detail_text) {
+                    if !root.join(&file_ref.path).is_file() {
+                        continue;
+                    }
+                    let abs_start = detail_start + file_ref.start as u32;
+                    let abs_end = detail_start + file_ref.end as u32;
+                    file_mentions.push((abs_start, abs_end, file_ref.path));
+                }
+            }
+        }
+    }
+
+    // Reference each mentioned file's `debian_file` symbol, scoped to the
+    // topmost source/version (matching the definitions the top-level indexer
+    // attaches to each document). Without a source name there is nothing to
+    // scope to, so the mentions are left unlinked.
+    if let Some(src) = source_name.as_deref() {
+        for (start, end, path) in file_mentions {
+            occurrences.push(Occurrence {
+                range: lines.range(start, end),
+                symbol: symbols::debian_file(src, topmost_version.as_deref(), &path),
+                syntax_kind: ScipSyntax::StringLiteral.into(),
+                ..Default::default()
+            });
         }
     }
 
@@ -173,7 +215,7 @@ hello (2.10-2) unstable; urgency=medium
 
     #[test]
     fn indexes_versions_and_bugs() {
-        let idx = index(SAMPLE, "debian/changelog");
+        let idx = index(SAMPLE, "debian/changelog", None);
         assert_eq!(idx.source_name.as_deref(), Some("hello"));
         assert_eq!(idx.topmost_version.as_deref(), Some("2.10-3"));
 
@@ -216,7 +258,7 @@ hello (2.10-2) unstable; urgency=medium
 
     #[test]
     fn indexes_cves() {
-        let idx = index(SAMPLE, "debian/changelog");
+        let idx = index(SAMPLE, "debian/changelog", None);
 
         let cve_refs: Vec<_> = idx
             .document
@@ -232,5 +274,73 @@ hello (2.10-2) unstable; urgency=medium
         );
 
         assert_eq!(idx.cves, BTreeSet::from(["CVE-2024-12345".to_string()]));
+    }
+
+    #[test]
+    fn indexes_file_mentions() {
+        const TEXT: &str = "\
+hello (2.10-3) unstable; urgency=medium
+
+  * d/control: Add python3-merge3 as Build Dependency.
+  * d/patches/03_fix.patch: Remove patch.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 27 May 2026 12:00:00 +0000
+";
+        let idx = index(TEXT, "debian/changelog", None);
+        let file_refs: Vec<_> = idx
+            .document
+            .occurrences
+            .iter()
+            .filter(|o| o.symbol.contains("file/"))
+            .map(|o| o.symbol.as_str())
+            .collect();
+
+        // Both mentions reference the `debian_file` symbol for their path,
+        // scoped to the topmost source/version.
+        assert_eq!(
+            file_refs,
+            vec![
+                symbols::debian_file("hello", Some("2.10-3"), "debian/control"),
+                symbols::debian_file("hello", Some("2.10-3"), "debian/patches/03_fix.patch"),
+            ]
+        );
+    }
+
+    #[test]
+    fn indexes_patch_word_mentions_only_when_existing() {
+        const TEXT: &str = "\
+hello (2.10-3) unstable; urgency=medium
+
+  * Drop obsolete patch relax-pyo3.patch.
+  * Add patch nonexistent.patch.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 27 May 2026 12:00:00 +0000
+";
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("debian/patches")).unwrap();
+        std::fs::write(
+            dir.path().join("debian/patches/relax-pyo3.patch"),
+            "--- a/x\n+++ b/x\n",
+        )
+        .unwrap();
+
+        let idx = index(TEXT, "debian/changelog", Some(dir.path()));
+        let file_refs: Vec<_> = idx
+            .document
+            .occurrences
+            .iter()
+            .filter(|o| o.symbol.contains("file/"))
+            .map(|o| o.symbol.as_str())
+            .collect();
+
+        // The existing patch is referenced; `nonexistent.patch` is not.
+        assert_eq!(
+            file_refs,
+            vec![symbols::debian_file(
+                "hello",
+                Some("2.10-3"),
+                "debian/patches/relax-pyo3.patch"
+            )]
+        );
     }
 }

--- a/src/scip/indexer.rs
+++ b/src/scip/indexer.rs
@@ -59,7 +59,7 @@ impl Indexer {
         // Step 1: changelog first, to learn the source name and current version.
         let changelog_text = std::fs::read_to_string(debian.join("changelog")).ok();
         let (source_name, version) = if let Some(text) = changelog_text.as_deref() {
-            let idx = changelog::index(text, "debian/changelog");
+            let idx = changelog::index(text, "debian/changelog", Some(&self.root));
             let src = idx.source_name.clone();
             let ver = idx.topmost_version.clone();
             bug_numbers.extend(idx.bug_numbers);
@@ -137,6 +137,25 @@ impl Indexer {
         if let Ok(text) = std::fs::read_to_string(debian.join("debcargo.toml")) {
             let idx = debcargo::index(&text, "debian/debcargo.toml", src, version.as_deref());
             documents.push(idx.document);
+        }
+
+        // Each document defines a `debian_file` symbol keyed by its path, so
+        // changelog mentions of a packaging file resolve to the file via "go
+        // to definition". Anchored at the start of the file.
+        for doc in &mut documents {
+            let sym = symbols::debian_file(src, version.as_deref(), &doc.relative_path);
+            doc.occurrences.push(scip::types::Occurrence {
+                range: vec![0, 0, 0, 0],
+                symbol: sym.clone(),
+                symbol_roles: scip::types::SymbolRole::Definition as i32,
+                ..Default::default()
+            });
+            doc.symbols.push(SymbolInformation {
+                symbol: sym,
+                kind: scip::types::symbol_information::Kind::File.into(),
+                display_name: doc.relative_path.clone(),
+                ..Default::default()
+            });
         }
 
         // External symbols carry hover information for things referenced from

--- a/src/scip/symbols.rs
+++ b/src/scip/symbols.rs
@@ -274,6 +274,24 @@ pub fn patch(source: &str, version: Option<&str>, patch_name: &str) -> String {
     })
 }
 
+/// Symbol for a packaging file under `debian/`, keyed by its path relative to
+/// the source-tree root (e.g. `debian/control`, `debian/patches/foo.patch`).
+///
+/// Each indexed document defines this symbol, so changelog mentions of a file
+/// can reference it and "go to definition" jumps to the file.
+pub fn debian_file(source: &str, version: Option<&str>, relative_path: &str) -> String {
+    fmt(Symbol {
+        scheme: SCHEME.to_owned(),
+        package: Some(pkg(source, version)).into(),
+        descriptors: vec![
+            desc(source, Suffix::Namespace),
+            desc("file", Suffix::Namespace),
+            desc(relative_path, Suffix::Meta),
+        ],
+        ..Default::default()
+    })
+}
+
 /// Symbol for a `Files:` paragraph glob in `debian/copyright`.
 pub fn copyright_files_glob(source: &str, version: Option<&str>, glob: &str) -> String {
     fmt(Symbol {

--- a/src/scip/tests.rs
+++ b/src/scip/tests.rs
@@ -10,7 +10,10 @@ fn write_tree(dir: &std::path::Path) {
         "hello (2.10-3) unstable; urgency=medium\n\n  \
         * Fix bug. (Closes: #777111)\n  \
         * Fix another. (LP: #2002003)\n  \
-        * Fix security issue (CVE-2024-12345).\n\n \
+        * Fix security issue (CVE-2024-12345).\n  \
+        * d/control: Add a dependency.\n  \
+        * d/patches/fix-segfault.patch: Refresh.\n  \
+        * Drop obsolete patch fix-segfault.patch.\n\n \
         -- Test User <test@example.org>  Tue, 27 May 2026 12:00:00 +0000\n",
     )
     .unwrap();
@@ -246,6 +249,44 @@ fn full_tree_round_trip() {
     scip::write_message_to_file(&out, index).expect("write");
     let bytes = fs::read(&out).unwrap();
     assert!(!bytes.is_empty());
+}
+
+#[test]
+fn changelog_file_mentions_resolve_cross_file() {
+    let dir = tempdir().unwrap();
+    write_tree(dir.path());
+
+    let index = Indexer::new(dir.path()).build();
+
+    let changelog = index
+        .documents
+        .iter()
+        .find(|d| d.relative_path == "debian/changelog")
+        .expect("changelog document");
+
+    // The changelog references the `debian_file` symbol for each mentioned
+    // file, scoped to the topmost source/version.
+    for path in ["debian/control", "debian/patches/fix-segfault.patch"] {
+        let sym = super::symbols::debian_file("hello", Some("2.10-3"), path);
+        assert!(
+            changelog.occurrences.iter().any(|o| o.symbol == sym
+                && (o.symbol_roles & scip::types::SymbolRole::Definition as i32) == 0),
+            "expected changelog reference to {path}"
+        );
+
+        // ...and the referenced document defines that same symbol, so the
+        // reference resolves to it.
+        let target = index
+            .documents
+            .iter()
+            .find(|d| d.relative_path == path)
+            .unwrap_or_else(|| panic!("missing document {path}"));
+        assert!(
+            target.occurrences.iter().any(|o| o.symbol == sym
+                && (o.symbol_roles & scip::types::SymbolRole::Definition as i32) != 0),
+            "expected {path} to define its debian_file symbol"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Changelog detail lines often refer to other packaging files (`d/control`, `d/patches/03_fix.patch`, `debian/tests/control`), to a patch by bare name (`Drop obsolete patch relax-pyo3.patch`), and to bugs they close. Surface those as navigation targets:

Fixes #323