### PR TITLE
Gate scip-only field description helpers behind the scip feature

### DIFF
--- a/src/debcargo/fields.rs
+++ b/src/debcargo/fields.rs
@@ -273,6 +273,7 @@ pub static MULTI_ARCH_VALUES: &[(&str, &str)] = &[
 ];
 
 /// Description of a top-level debcargo.toml key, if known.
+#[cfg(feature = "scip")]
 pub fn top_level_key_description(name: &str) -> Option<&'static str> {
     TOP_LEVEL_KEYS
         .iter()
@@ -281,6 +282,7 @@ pub fn top_level_key_description(name: &str) -> Option<&'static str> {
 }
 
 /// Description of a `[source]` table key, if known.
+#[cfg(feature = "scip")]
 pub fn source_key_description(name: &str) -> Option<&'static str> {
     SOURCE_KEYS
         .iter()
@@ -289,6 +291,7 @@ pub fn source_key_description(name: &str) -> Option<&'static str> {
 }
 
 /// Description of a `[packages.*]` table key, if known.
+#[cfg(feature = "scip")]
 pub fn package_key_description(name: &str) -> Option<&'static str> {
     PACKAGE_KEYS
         .iter()

--- a/src/tests/fields.rs
+++ b/src/tests/fields.rs
@@ -81,6 +81,7 @@ pub const TESTS_DEPENDS_SUBSTITUTION_VALUES: &[(&str, &str)] = &[
 ];
 
 /// Look up a description for an autopkgtest restriction name.
+#[cfg(any(feature = "scip", test))]
 pub fn restriction_description(name: &str) -> Option<&'static str> {
     TESTS_RESTRICTIONS_VALUES
         .iter()
@@ -89,6 +90,7 @@ pub fn restriction_description(name: &str) -> Option<&'static str> {
 }
 
 /// Look up a description for an autopkgtest feature name.
+#[cfg(any(feature = "scip", test))]
 pub fn feature_description(name: &str) -> Option<&'static str> {
     TESTS_FEATURES_VALUES
         .iter()


### PR DESCRIPTION
These functions are only used from the scip module, so a default build (without the scip feature) reported them as dead code.