### PR TITLE
debhelper: add shared source-tree scanner

### DIFF
--- a/src/copyright/code_lens.rs
+++ b/src/copyright/code_lens.rs
@@ -100,7 +100,7 @@ async fn get_file_count_lenses(
         Some(files) => files,
         None => {
             let root_buf = root.to_path_buf();
-            tokio::task::spawn_blocking(move || git_ls_files(&root_buf))
+            tokio::task::spawn_blocking(move || crate::source_scan::git_ls_files(&root_buf))
                 .await
                 .ok()
                 .flatten()?
@@ -174,37 +174,6 @@ async fn get_file_count_lenses(
     }
 
     Some(lenses)
-}
-
-/// List git-tracked files relative to the given working directory.
-fn git_ls_files(root: &Path) -> Option<Vec<String>> {
-    let output = match std::process::Command::new("git")
-        .arg("ls-files")
-        .arg("-z")
-        .current_dir(root)
-        .output()
-    {
-        Ok(o) => o,
-        Err(e) => {
-            tracing::warn!("failed to run git ls-files in {}: {e}", root.display());
-            return None;
-        }
-    };
-    if !output.status.success() {
-        tracing::info!(
-            "git ls-files failed in {} (not a git repo?)",
-            root.display()
-        );
-        return None;
-    }
-    Some(
-        output
-            .stdout
-            .split(|&b| b == 0)
-            .filter(|s| !s.is_empty())
-            .filter_map(|s| std::str::from_utf8(s).ok().map(|s| s.to_string()))
-            .collect(),
-    )
 }
 
 /// Generate code lenses for copyright license and files paragraphs.

--- a/src/debhelper/mod.rs
+++ b/src/debhelper/mod.rs
@@ -4,3 +4,4 @@ pub mod detection;
 pub mod dirs;
 pub mod parser;
 pub mod semantic;
+pub mod source;

--- a/src/debhelper/source.rs
+++ b/src/debhelper/source.rs
@@ -1,0 +1,70 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use tower_lsp_server::ls_types::CompletionItem;
+
+use crate::source_scan;
+
+/// Install-source candidates for a path token: files tracked in the source
+/// tree plus staged build output under debian/tmp.
+pub(crate) fn source_candidates(debian_dir: &Path, prefix: &str) -> Vec<CompletionItem> {
+    let mut found: BTreeMap<String, bool> = BTreeMap::new();
+    if let Some(root) = debian_dir.parent() {
+        source_scan::record_tracked(root, prefix, &mut found);
+    }
+    record_staged(debian_dir, prefix, &mut found);
+    source_scan::shape(found)
+}
+
+/// Staged build output under debian/tmp for a path token.
+pub(crate) fn staged_candidates(debian_dir: &Path, prefix: &str) -> Vec<CompletionItem> {
+    let mut found: BTreeMap<String, bool> = BTreeMap::new();
+    record_staged(debian_dir, prefix, &mut found);
+    source_scan::shape(found)
+}
+
+/// Record entries directly under debian/tmp/<dir> that match `prefix`.
+// FIXME: debian/tmp is only a convention; a package can install to a
+// different directory (e.g. dh_auto_install --destdir).
+fn record_staged(debian_dir: &Path, prefix: &str, out: &mut BTreeMap<String, bool>) {
+    let dir = source_scan::dir_prefix(prefix);
+    if let Ok(entries) = std::fs::read_dir(debian_dir.join("tmp").join(dir)) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let candidate = format!("{dir}{}", name.to_string_lossy());
+            if candidate.starts_with(prefix) {
+                let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                out.insert(candidate, is_dir);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_scan::git_tree;
+
+    fn labels(items: &[CompletionItem]) -> Vec<String> {
+        items.iter().map(|i| i.label.clone()).collect()
+    }
+
+    #[test]
+    fn source_candidates_offers_tree_and_debian_tmp() {
+        let dir = git_tree(&["README", "debian/tmp/usr/bin/prog"], &[]);
+        let debian = dir.path().join("debian");
+        let top = labels(&source_candidates(&debian, ""));
+        assert!(top.contains(&"README".to_string()));
+        assert!(top.contains(&"usr/".to_string()));
+    }
+
+    #[test]
+    fn staged_candidates_offers_only_debian_tmp() {
+        let dir = git_tree(&["README", "debian/tmp/usr/bin/prog"], &[]);
+        let debian = dir.path().join("debian");
+        assert!(
+            labels(&staged_candidates(&debian, "usr/bin/")).contains(&"usr/bin/prog".to_string())
+        );
+        assert!(!labels(&staged_candidates(&debian, "")).contains(&"README".to_string()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ mod rules;
 mod scip;
 mod source_format;
 mod source_options;
+mod source_scan;
 #[cfg(feature = "spellcheck")]
 mod spelling;
 mod tests;

--- a/src/source_scan.rs
+++ b/src/source_scan.rs
@@ -1,0 +1,179 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+use tower_lsp_server::ls_types::{CompletionItem, CompletionItemKind};
+
+/// List git-tracked files relative to `root`.
+pub(crate) fn git_ls_files(root: &Path) -> Option<Vec<String>> {
+    let output = match Command::new("git")
+        .arg("ls-files")
+        .arg("-z")
+        .current_dir(root)
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!("failed to run git ls-files in {}: {e}", root.display());
+            return None;
+        }
+    };
+    if !output.status.success() {
+        tracing::info!(
+            "git ls-files failed in {} (not a git repo?)",
+            root.display()
+        );
+        return None;
+    }
+    Some(
+        output
+            .stdout
+            .split(|&b| b == 0)
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| std::str::from_utf8(s).ok().map(str::to_string))
+            .collect(),
+    )
+}
+
+/// Source candidates for a path token, from the files tracked under `root`.
+pub fn source_candidates(root: &Path, prefix: &str) -> Vec<CompletionItem> {
+    let mut found: BTreeMap<String, bool> = BTreeMap::new();
+    record_tracked(root, prefix, &mut found);
+    shape(found)
+}
+
+/// Record git-tracked files under `root` at the current directory level.
+pub(crate) fn record_tracked(root: &Path, prefix: &str, out: &mut BTreeMap<String, bool>) {
+    let dir = dir_prefix(prefix);
+    if let Some(files) = git_ls_files(root) {
+        for file in &files {
+            record(file, dir, prefix, out);
+        }
+    }
+}
+
+/// The directory portion of `prefix`, up to and including the last slash.
+pub(crate) fn dir_prefix(prefix: &str) -> &str {
+    match prefix.rfind('/') {
+        Some(i) => &prefix[..=i],
+        None => "",
+    }
+}
+
+/// Turn the collected path -> is_dir map into completion items.
+pub(crate) fn shape(found: BTreeMap<String, bool>) -> Vec<CompletionItem> {
+    found
+        .into_iter()
+        .map(|(path, is_dir)| {
+            let (label, kind) = if is_dir {
+                (format!("{path}/"), CompletionItemKind::FOLDER)
+            } else {
+                (path, CompletionItemKind::FILE)
+            };
+            CompletionItem {
+                label,
+                kind: Some(kind),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+/// Offer `file`'s entry at the current directory level `dir`: either the
+/// file itself, or the subdirectory that leads to it.
+fn record(file: &str, dir: &str, prefix: &str, out: &mut BTreeMap<String, bool>) {
+    let Some(rest) = file.strip_prefix(dir) else {
+        return;
+    };
+    let (candidate, is_dir) = match rest.find('/') {
+        Some(i) => (&file[..dir.len() + i], true),
+        None => (file, false),
+    };
+    if candidate.starts_with(prefix) {
+        out.insert(candidate.to_string(), is_dir);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn git_tree(tracked: &[&str], untracked: &[&str]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    run_git(root, &["init"]);
+    for rel in tracked.iter().chain(untracked) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "").unwrap();
+    }
+    for rel in tracked {
+        run_git(root, &["add", rel]);
+    }
+    dir
+}
+
+#[cfg(test)]
+fn run_git(root: &Path, args: &[&str]) {
+    Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(items: &[CompletionItem]) -> Vec<String> {
+        items.iter().map(|i| i.label.clone()).collect()
+    }
+
+    #[test]
+    fn offers_files_from_the_tree() {
+        let dir = git_tree(&["src/main.rs", "README"], &[]);
+        let labels = labels(&source_candidates(dir.path(), ""));
+        assert!(labels.contains(&"README".to_string()));
+        assert!(labels.contains(&"src/".to_string()));
+    }
+
+    #[test]
+    fn includes_files_under_debian() {
+        let dir = git_tree(&["debian/foo.1", "debian/control"], &[]);
+        let labels = labels(&source_candidates(dir.path(), "debian/"));
+        assert!(labels.contains(&"debian/foo.1".to_string()));
+        assert!(labels.contains(&"debian/control".to_string()));
+    }
+
+    #[test]
+    fn offers_only_the_current_directory_level() {
+        let dir = git_tree(&["usr/bin/foo", "usr/lib/bar"], &[]);
+        let top = labels(&source_candidates(dir.path(), ""));
+        assert_eq!(top, vec!["usr/".to_string()]);
+        let under_usr = labels(&source_candidates(dir.path(), "usr/"));
+        assert_eq!(
+            under_usr,
+            vec!["usr/bin/".to_string(), "usr/lib/".to_string()]
+        );
+    }
+
+    #[test]
+    fn filters_by_prefix() {
+        let dir = git_tree(&["usr/bin/foo", "usr/lib/bar", "etc/conf"], &[]);
+        let labels = labels(&source_candidates(dir.path(), "usr/"));
+        assert!(labels.iter().all(|l| l.starts_with("usr/")));
+        assert!(!labels.iter().any(|l| l.starts_with("etc")));
+    }
+
+    #[test]
+    fn directories_end_with_a_slash() {
+        let dir = git_tree(&["src/main.rs"], &[]);
+        let items = source_candidates(dir.path(), "src");
+        let src = items.iter().find(|i| i.label == "src/").unwrap();
+        assert_eq!(src.kind, Some(CompletionItemKind::FOLDER));
+    }
+
+    #[test]
+    fn no_match_is_empty() {
+        let dir = git_tree(&["README"], &[]);
+        assert!(source_candidates(dir.path(), "usr/").is_empty());
+    }
+}


### PR DESCRIPTION
stacked on top of https://github.com/jelmer/debian-lsp/pull/376